### PR TITLE
[NEMO-29] Update GitHub Main README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,14 @@
 # Nemo
 
-[![Build Status](https://travis-ci.org/snuspl/nemo.svg?branch=master)](https://travis-ci.org/snuspl/nemo)
-[![Build Status](https://cmsbuild.snu.ac.kr/buildStatus/icon?job=Nemo-master)](https://cmsbuild.snu.ac.kr/job/Nemo-master/)
+[![Build Status](https://travis-ci.org/apache/incubator-nemo.svg?branch=master)](https://travis-ci.org/apache/incubator-nemo)
+
+A Data Processing System for Flexible Employment With Different Deployment Characteristics.
+
+## Online Documentation
+
+Details about Nemo and its development can be found in:
+* Our website: http://nemo.apache.org/
+* Our project wiki: https://cwiki.apache.org/confluence/display/NEMO/
 
 ## Nemo prerequisites and setup
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Data Processing System for Flexible Employment With Different Deployment Chara
 ## Online Documentation
 
 Details about Nemo and its development can be found in:
-* Our website: http://nemo.apache.org/
+* Our website: https://nemo.apache.org/
 * Our project wiki: https://cwiki.apache.org/confluence/display/NEMO/
 
 ## Nemo prerequisites and setup


### PR DESCRIPTION
JIRA: [NEMO-29: Update GitHub main page for initial migration to ASF](https://issues.apache.org/jira/browse/NEMO-29)

**Major changes:**

- README.md modified to reflect our code migration to Apache.

**Minor changes to note:**
- None

**Tests for the changes:**

- Not required

**Other comments:**

- The contents below prerequisites and setup should soon move to either the website or the wiki.