### PR TITLE
[NEMO-39] SonarCloud Bugs and Vulnerabilities for RuntimeExecutor

### DIFF
--- a/runtime/executor/src/main/java/edu/snu/nemo/runtime/executor/TaskGroupExecutor.java
+++ b/runtime/executor/src/main/java/edu/snu/nemo/runtime/executor/TaskGroupExecutor.java
@@ -207,11 +207,13 @@ public final class TaskGroupExecutor {
             Optional.of(TaskGroupState.RecoverableFailureCause.INPUT_READ_FAILURE));
         LOG.warn("{} Execution Failed (Recoverable)! Exception: {}",
             new Object[] {taskGroupId, ex.toString()});
+        Thread.currentThread().interrupt();
       } catch (final BlockWriteException ex2) {
         taskGroupStateManager.onTaskStateChanged(physicalTaskId, TaskState.State.FAILED_RECOVERABLE,
             Optional.of(TaskGroupState.RecoverableFailureCause.OUTPUT_WRITE_FAILURE));
         LOG.warn("{} Execution Failed (Recoverable)! Exception: {}",
             new Object[] {taskGroupId, ex2.toString()});
+        Thread.currentThread().interrupt();
       } catch (final Exception e) {
         taskGroupStateManager.onTaskStateChanged(
             physicalTaskId, TaskState.State.FAILED_UNRECOVERABLE, Optional.empty());
@@ -290,7 +292,10 @@ public final class TaskGroupExecutor {
             }
             sideInputMap.put(srcTransform, sideInput);
             sideInputIterators.add(sideInputIterator);
-          } catch (final InterruptedException | ExecutionException e) {
+          } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new BlockFetchException(e);
+          } catch (final ExecutionException e) {
             throw new BlockFetchException(e);
           }
         });
@@ -347,6 +352,7 @@ public final class TaskGroupExecutor {
           }
         }
       } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
         throw new BlockFetchException(e);
       }
 
@@ -424,6 +430,7 @@ public final class TaskGroupExecutor {
           }
         }
       } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
         throw new BlockFetchException(e);
       }
     }

--- a/runtime/executor/src/main/java/edu/snu/nemo/runtime/executor/bytetransfer/ByteInputContext.java
+++ b/runtime/executor/src/main/java/edu/snu/nemo/runtime/executor/bytetransfer/ByteInputContext.java
@@ -16,11 +16,14 @@
 package edu.snu.nemo.runtime.executor.bytetransfer;
 
 import io.netty.buffer.ByteBuf;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Iterator;
+import java.util.NoSuchElementException;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -34,6 +37,8 @@ import java.util.concurrent.CompletableFuture;
  */
 public final class ByteInputContext extends ByteTransferContext {
 
+  private static final Logger LOG = LoggerFactory.getLogger(ByteInputContext.class.getName());
+
   private final CompletableFuture<Iterator<InputStream>> completedFuture = new CompletableFuture<>();
   private final ClosableBlockingQueue<ByteBufInputStream> byteBufInputStreams = new ClosableBlockingQueue<>();
   private volatile ByteBufInputStream currentByteBufInputStream = null;
@@ -44,6 +49,7 @@ public final class ByteInputContext extends ByteTransferContext {
       try {
         return byteBufInputStreams.peek() != null;
       } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
         throw new RuntimeException(e);
       }
     }
@@ -53,7 +59,9 @@ public final class ByteInputContext extends ByteTransferContext {
       try {
         return byteBufInputStreams.take();
       } catch (final InterruptedException e) {
-        throw new RuntimeException(e);
+        Thread.currentThread().interrupt();
+        LOG.error("Interrupted while taking byte buf.", e);
+        throw new NoSuchElementException();
       }
     }
   };
@@ -162,6 +170,7 @@ public final class ByteInputContext extends ByteTransferContext {
         }
         return b;
       } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
         throw new IOException(e);
       }
     }
@@ -196,6 +205,7 @@ public final class ByteInputContext extends ByteTransferContext {
         }
         return readBytes;
       } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
         throw new IOException(e);
       }
     }
@@ -230,6 +240,7 @@ public final class ByteInputContext extends ByteTransferContext {
         }
         return skippedBytes;
       } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
         throw new IOException(e);
       }
     }
@@ -244,6 +255,7 @@ public final class ByteInputContext extends ByteTransferContext {
           return head.readableBytes();
         }
       } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
         throw new IOException(e);
       }
     }

--- a/runtime/executor/src/main/java/edu/snu/nemo/runtime/executor/bytetransfer/ByteTransport.java
+++ b/runtime/executor/src/main/java/edu/snu/nemo/runtime/executor/bytetransfer/ByteTransport.java
@@ -125,6 +125,7 @@ final class ByteTransport implements AutoCloseable {
             break;
           }
         } catch (final InterruptedException e) {
+          Thread.currentThread().interrupt();
           LOG.debug(String.format("Interrupted while binding to %s:%d", host, candidatePort), e);
         }
       }


### PR DESCRIPTION
JIRA: [NEMO-39](https://issues.apache.org/jira/browse/NEMO-39)

**Major changes:**
- Minor changes to meet SonarCloud criteria (including interrupting threads when `InterruptedException` occurs).

**Minor changes to note:**
- None

**Tests for the changes:**
- Existing tests cover the changes.

**Other comments:**
- None

resolves [NEMO-39](https://issues.apache.org/jira/browse/NEMO-39)