### PR TITLE
[NEMO-43] Sonar cloud script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,8 @@ jdk:
   - oraclejdk8
 script:
   # the following command line builds the project, runs the tests with coverage and then execute the SonarCloud analysis
-  - if [ "$TRAVIS_PULL_REQUEST" == false ]; then mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent verify sonar:sonar -B -q -ff -Dsurefire.useFile=false -Dorg.slf4j.simpleLogger.defaultLogLevel=info; fi
-  - if [ "$TRAVIS_PULL_REQUEST" != false ]; then mvn clean verify -B -q -ff -Dsurefire.useFile=false -Dorg.slf4j.simpleLogger.defaultLogLevel=info; fi
+  - if [ "$TRAVIS_PULL_REQUEST" == false ]; then travis_retry mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent verify sonar:sonar -B -q -ff -Dsurefire.useFile=false -Dorg.slf4j.simpleLogger.defaultLogLevel=info; fi
+  - if [ "$TRAVIS_PULL_REQUEST" != false ]; then travis_retry mvn clean verify -B -q -ff -Dsurefire.useFile=false -Dorg.slf4j.simpleLogger.defaultLogLevel=info; fi
 
 notifications:
   slack:

--- a/bin/sonar_qube.sh
+++ b/bin/sonar_qube.sh
@@ -2,4 +2,5 @@
 
 echo "You should already have SonarQube installed and running at localhost:9000"
 echo "e.g. OSX: brew install sonarqube && sonar console"
+sonar console
 mvn clean package sonar:sonar

--- a/bin/sonar_qube.sh
+++ b/bin/sonar_qube.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+echo "You should already have SonarQube installed and running at localhost:9000"
+echo "e.g. brew install sonarqube && sonar console"
+mvn clean package sonar:sonar

--- a/bin/sonar_qube.sh
+++ b/bin/sonar_qube.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
 echo "You should already have SonarQube installed and running at localhost:9000"
-echo "e.g. brew install sonarqube && sonar console"
+echo "e.g. OSX: brew install sonarqube && sonar console"
 mvn clean package sonar:sonar

--- a/bin/sonar_qube.sh
+++ b/bin/sonar_qube.sh
@@ -1,4 +1,18 @@
 #!/usr/bin/env bash
+#
+# Copyright (C) 2017 Seoul National University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 echo "You should already have SonarQube installed and running at localhost:9000"
 echo "e.g. OSX: brew install sonarqube && sonar console"

--- a/compiler/frontend/spark/src/main/java/edu/snu/nemo/compiler/frontend/spark/sql/SparkSession.java
+++ b/compiler/frontend/spark/src/main/java/edu/snu/nemo/compiler/frontend/spark/sql/SparkSession.java
@@ -115,9 +115,9 @@ public final class SparkSession extends org.apache.spark.sql.SparkSession implem
       final Object[] args = command.getValue();
       final Class<?>[] argTypes = Stream.of(args).map(Object::getClass).toArray(Class[]::new);
 
-      if (!SparkSession.class.getName().equals(className)
-          && !DataFrameReader.class.getName().equals(className)
-          && !Dataset.class.getName().equals(className)) {
+      if (!className.contains("SparkSession")
+          && !className.contains("DataFrameReader")
+          && !className.contains("Dataset")) {
         throw new OperationNotSupportedException(command + " is not yet supported.");
       }
 

--- a/pom.xml
+++ b/pom.xml
@@ -140,6 +140,15 @@ limitations under the License.
             </extension>
         </extensions>
 
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>sonar-maven-plugin</artifactId>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
JIRA: [NEMO-43: Sonar cloud script](https://issues.apache.org/jira/projects/NEMO/issues/NEMO-43)

**Major changes:**
- Add sonar qube script to run sonar analysis locally with maven

**Minor changes to note:**
- Minor change to check whether or not sonar qube detects the change made to fix sonar analysis.
- Minor change to travis script to automatically retry builds that are failed due to resource constraints.

**Tests for the changes:**
- Existing ITCases cover this change.

**Other comments:**
- No comments.

resolves [NEMO-43](https://issues.apache.org/jira/projects/NEMO/issues/NEMO-43)