### PR TITLE
[NEMO-46] Make the operations on ExecutorRegistry atomic

### DIFF
--- a/runtime/master/src/main/java/edu/snu/nemo/runtime/master/JobStateManager.java
+++ b/runtime/master/src/main/java/edu/snu/nemo/runtime/master/JobStateManager.java
@@ -67,7 +67,7 @@ public final class JobStateManager {
 
   /**
    * Maintain the number of schedule attempts for each task.
-   * The attempt numbers are update only here, and are read-only in other places.
+   * The attempt numbers are updated only here, and are read-only in other places.
    */
   private final Map<String, Integer> taskIdToCurrentAttempt;
 
@@ -306,8 +306,6 @@ public final class JobStateManager {
         throw new IllegalStateTransitionException(
             new Throwable("The stage has not yet been submitted for execution"));
       }
-
-      taskIdToCurrentAttempt.put(taskId, taskIdToCurrentAttempt.get(taskId) + 1);
       break;
     case EXECUTING:
       taskState.setState(newState);
@@ -334,12 +332,13 @@ public final class JobStateManager {
           throw new IllegalStateTransitionException(
               new Throwable("The stage has not yet been submitted for execution"));
         }
+
+        // We'll recover and retry this task
+        taskIdToCurrentAttempt.put(taskId, taskIdToCurrentAttempt.get(taskId) + 1);
       } else {
         LOG.info("{} state is already FAILED_RECOVERABLE. Skipping this event.",
             taskId);
       }
-
-      taskIdToCurrentAttempt.put(taskId, taskIdToCurrentAttempt.get(taskId) + 1);
       break;
     case READY:
       taskState.setState(newState);

--- a/runtime/master/src/main/java/edu/snu/nemo/runtime/master/JobStateManager.java
+++ b/runtime/master/src/main/java/edu/snu/nemo/runtime/master/JobStateManager.java
@@ -66,7 +66,8 @@ public final class JobStateManager {
   private final Map<String, TaskState> idToTaskStates;
 
   /**
-   * Keeps track of the number of schedule attempts for each task.
+   * Maintain the number of schedule attempts for each task.
+   * The attempt numbers are update only here, and are read-only in other places.
    */
   private final Map<String, Integer> taskIdToCurrentAttempt;
 

--- a/runtime/master/src/main/java/edu/snu/nemo/runtime/master/RuntimeMaster.java
+++ b/runtime/master/src/main/java/edu/snu/nemo/runtime/master/RuntimeMaster.java
@@ -53,6 +53,7 @@ import static edu.snu.nemo.runtime.common.state.TaskState.State.ON_HOLD;
 
 /**
  * (WARNING) Use runtimeMasterThread for all public methods to avoid race conditions.
+ * See comments in the {@link Scheduler} for avoiding race conditions.
  *
  * Runtime Master is the central controller of Runtime.
  * Compiler submits an {@link PhysicalPlan} to Runtime Master to execute a job.

--- a/runtime/master/src/main/java/edu/snu/nemo/runtime/master/RuntimeMaster.java
+++ b/runtime/master/src/main/java/edu/snu/nemo/runtime/master/RuntimeMaster.java
@@ -265,8 +265,8 @@ public final class RuntimeMaster {
 
         scheduler.onTaskStateChanged(taskStateChangedMsg.getExecutorId(),
             taskStateChangedMsg.getTaskId(),
-            convertTaskState(taskStateChangedMsg.getState()),
             taskStateChangedMsg.getAttemptIdx(),
+            convertTaskState(taskStateChangedMsg.getState()),
             taskStateChangedMsg.getTaskPutOnHoldId(),
             convertFailureCause(taskStateChangedMsg.getFailureCause()));
         break;

--- a/runtime/master/src/main/java/edu/snu/nemo/runtime/master/resource/ExecutorRepresenter.java
+++ b/runtime/master/src/main/java/edu/snu/nemo/runtime/master/resource/ExecutorRepresenter.java
@@ -82,9 +82,11 @@ public final class ExecutorRepresenter {
   /**
    * Marks all Tasks which were running in this executor as failed.
    */
-  public void onExecutorFailed() {
-    runningTasks.forEach(taskId -> failedTasks.add(taskId));
+  public Set<String> onExecutorFailed() {
+    failedTasks.addAll(runningTasks);
+    final Set<String> snapshot = new HashSet<>(runningTasks);
     runningTasks.clear();
+    return snapshot;
   }
 
   /**

--- a/runtime/master/src/main/java/edu/snu/nemo/runtime/master/resource/ExecutorRepresenter.java
+++ b/runtime/master/src/main/java/edu/snu/nemo/runtime/master/resource/ExecutorRepresenter.java
@@ -25,7 +25,9 @@ import org.apache.commons.lang3.SerializationUtils;
 import org.apache.reef.driver.context.ActiveContext;
 
 import javax.annotation.concurrent.NotThreadSafe;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 
@@ -46,6 +48,7 @@ public final class ExecutorRepresenter {
   private final String executorId;
   private final ResourceSpecification resourceSpecification;
   private final Set<String> runningTasks;
+  private final Map<String, Integer> runningTaskToAttempt;
   private final Set<String> completeTasks;
   private final Set<String> failedTasks;
   private final MessageSender<ControlMessage.Message> messageSender;
@@ -72,6 +75,7 @@ public final class ExecutorRepresenter {
     this.resourceSpecification = resourceSpecification;
     this.messageSender = messageSender;
     this.runningTasks = new HashSet<>();
+    this.runningTaskToAttempt = new HashMap<>();
     this.completeTasks = new HashSet<>();
     this.failedTasks = new HashSet<>();
     this.activeContext = activeContext;
@@ -95,6 +99,7 @@ public final class ExecutorRepresenter {
    */
   public void onTaskScheduled(final ScheduledTask scheduledTask) {
     runningTasks.add(scheduledTask.getTaskId());
+    runningTaskToAttempt.put(scheduledTask.getTaskId(), scheduledTask.getAttemptIdx());
     failedTasks.remove(scheduledTask.getTaskId());
 
     serializationExecutorService.submit(new Runnable() {
@@ -125,10 +130,11 @@ public final class ExecutorRepresenter {
 
   /**
    * Marks the specified Task as completed.
-   * @param taskId id of the Task
+   *
    */
   public void onTaskExecutionComplete(final String taskId) {
     runningTasks.remove(taskId);
+    runningTaskToAttempt.remove(taskId);
     completeTasks.add(taskId);
   }
 
@@ -138,6 +144,7 @@ public final class ExecutorRepresenter {
    */
   public void onTaskExecutionFailed(final String taskId) {
     runningTasks.remove(taskId);
+    runningTaskToAttempt.remove(taskId);
     failedTasks.add(taskId);
   }
 
@@ -155,9 +162,13 @@ public final class ExecutorRepresenter {
     return runningTasks;
   }
 
+  public Map<String, Integer> getRunningTaskToAttempt() {
+    return runningTaskToAttempt;
+  }
+
   /**
    * @return set of ids of Tasks that have been failed in this exeuctor
-   */
+
   public Set<String> getFailedTasks() {
     return failedTasks;
   }

--- a/runtime/master/src/main/java/edu/snu/nemo/runtime/master/resource/ExecutorRepresenter.java
+++ b/runtime/master/src/main/java/edu/snu/nemo/runtime/master/resource/ExecutorRepresenter.java
@@ -32,7 +32,7 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 
 /**
- * (WARNING) This class is not thread-safe.
+ * (WARNING) This class is not thread-safe, and thus should only be accessed through ExecutorRegistry.
  *
  * Contains information/state regarding an executor.
  * Such information may include:

--- a/runtime/master/src/main/java/edu/snu/nemo/runtime/master/scheduler/BatchSingleJobScheduler.java
+++ b/runtime/master/src/main/java/edu/snu/nemo/runtime/master/scheduler/BatchSingleJobScheduler.java
@@ -101,8 +101,7 @@ public final class BatchSingleJobScheduler implements Scheduler {
    * @param scheduledJobStateManager to keep track of the submitted job's states.
    */
   @Override
-  public void scheduleJob(final PhysicalPlan jobToSchedule,
-                          final JobStateManager scheduledJobStateManager) {
+  public void scheduleJob(final PhysicalPlan jobToSchedule, final JobStateManager scheduledJobStateManager) {
     this.physicalPlan = jobToSchedule;
     this.jobStateManager = scheduledJobStateManager;
 

--- a/runtime/master/src/main/java/edu/snu/nemo/runtime/master/scheduler/BatchSingleJobScheduler.java
+++ b/runtime/master/src/main/java/edu/snu/nemo/runtime/master/scheduler/BatchSingleJobScheduler.java
@@ -172,6 +172,10 @@ public final class BatchSingleJobScheduler implements Scheduler {
       }
     } else if (taskAttemptIndex < currentTaskAttemptIndex) {
       // Do not change state, as this notification is for a previous task attempt.
+      // For example, the master can receive a notification that an executor has been removed,
+      // and then a notification that the task that was running in the removed executor has been completed.
+      // In this case, if we do not consider the attempt number, the state changes from FAILED_RECOVERABLE to COMPLETED,
+      // which is illegal.
       LOG.info("{} state change to {} arrived late, we will ignore this.", new Object[]{taskId, newState});
     } else {
       throw new SchedulingException(new Throwable("AttemptIdx for a task cannot be greater than its current index"));

--- a/runtime/master/src/main/java/edu/snu/nemo/runtime/master/scheduler/BatchSingleJobScheduler.java
+++ b/runtime/master/src/main/java/edu/snu/nemo/runtime/master/scheduler/BatchSingleJobScheduler.java
@@ -189,10 +189,11 @@ public final class BatchSingleJobScheduler implements Scheduler {
       tasksToReExecute.addAll(executor.onExecutorFailed());
       return Pair.of(executor, ExecutorRegistry.ExecutorState.FAILED);
     });
+
     tasksToReExecute.forEach(failedTaskId -> {
       final int attemptIndex = jobStateManager.getCurrentAttemptIndexForTask(failedTaskId);
       onTaskStateChanged(executorId, failedTaskId, TaskState.State.FAILED_RECOVERABLE,
-          SCHEDULE_ATTEMPT_ON_CONTAINER_FAILURE, null, TaskState.RecoverableFailureCause.CONTAINER_FAILURE);
+          attemptIndex, null, TaskState.RecoverableFailureCause.CONTAINER_FAILURE);
     });
 
     if (!tasksToReExecute.isEmpty()) {

--- a/runtime/master/src/main/java/edu/snu/nemo/runtime/master/scheduler/ExecutorRegistry.java
+++ b/runtime/master/src/main/java/edu/snu/nemo/runtime/master/scheduler/ExecutorRegistry.java
@@ -59,7 +59,7 @@ public final class ExecutorRegistry {
     }
   }
 
-  synchronized boolean registerTask(final SchedulingPolicy policy, final ScheduledTask task) {
+  synchronized boolean scheduleAndRegisterTask(final SchedulingPolicy policy, final ScheduledTask task) {
     final Set<ExecutorRepresenter> candidateExecutors =
         policy.filterExecutorRepresenters(getRunningExecutors(), task);
     final Optional<ExecutorRepresenter> firstCandidate = candidateExecutors.stream().findFirst();

--- a/runtime/master/src/main/java/edu/snu/nemo/runtime/master/scheduler/ExecutorRegistry.java
+++ b/runtime/master/src/main/java/edu/snu/nemo/runtime/master/scheduler/ExecutorRegistry.java
@@ -17,7 +17,6 @@ package edu.snu.nemo.runtime.master.scheduler;
 
 import com.google.common.annotations.VisibleForTesting;
 import edu.snu.nemo.common.Pair;
-import edu.snu.nemo.runtime.common.plan.physical.ScheduledTask;
 import edu.snu.nemo.runtime.master.resource.ExecutorRepresenter;
 import org.apache.reef.annotations.audience.DriverSide;
 
@@ -25,6 +24,7 @@ import javax.annotation.concurrent.ThreadSafe;
 import javax.inject.Inject;
 import java.util.*;
 import java.util.function.BiFunction;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 /**
@@ -55,22 +55,13 @@ public final class ExecutorRegistry {
     if (executors.containsKey(executorId)) {
       throw new IllegalArgumentException("Duplicate executor: " + executor.toString());
     } else {
+      // System.out.println("executor registered " + executor.getExecutorId());
       executors.put(executorId, Pair.of(executor, ExecutorState.RUNNING));
     }
   }
 
-  synchronized boolean scheduleAndRegisterTask(final SchedulingPolicy policy, final ScheduledTask task) {
-    final Set<ExecutorRepresenter> candidateExecutors =
-        policy.filterExecutorRepresenters(getRunningExecutors(), task);
-    final Optional<ExecutorRepresenter> firstCandidate = candidateExecutors.stream().findFirst();
-
-    if (firstCandidate.isPresent()) {
-      final ExecutorRepresenter selectedExecutor = firstCandidate.get();
-      selectedExecutor.onTaskScheduled(task);
-      return true;
-    } else {
-      return false;
-    }
+  synchronized void viewExecutors(final Consumer<Set<ExecutorRepresenter>> consumer) {
+    consumer.accept(getRunningExecutors());
   }
 
   synchronized void updateExecutor(

--- a/runtime/master/src/main/java/edu/snu/nemo/runtime/master/scheduler/ExecutorRegistry.java
+++ b/runtime/master/src/main/java/edu/snu/nemo/runtime/master/scheduler/ExecutorRegistry.java
@@ -55,8 +55,7 @@ public final class ExecutorRegistry {
     }
   }
 
-  synchronized Optional<ExecutorRepresenter> registerTask(final SchedulingPolicy policy,
-                                                          final ScheduledTask task) {
+  synchronized boolean registerTask(final SchedulingPolicy policy, final ScheduledTask task) {
     final Set<ExecutorRepresenter> candidateExecutors =
         policy.filterExecutorRepresenters(getRunningExecutors(), task);
     final Optional<ExecutorRepresenter> firstCandiate = candidateExecutors.stream().findFirst();
@@ -64,9 +63,9 @@ public final class ExecutorRegistry {
     if (firstCandiate.isPresent()) {
       final ExecutorRepresenter selectedExecutor = firstCandiate.get();
       selectedExecutor.onTaskScheduled(task);
-      return Optional.of(selectedExecutor);
+      return true;
     } else {
-      return Optional.empty();
+      return false;
     }
   }
 

--- a/runtime/master/src/main/java/edu/snu/nemo/runtime/master/scheduler/ExecutorRegistry.java
+++ b/runtime/master/src/main/java/edu/snu/nemo/runtime/master/scheduler/ExecutorRegistry.java
@@ -62,10 +62,10 @@ public final class ExecutorRegistry {
   synchronized boolean registerTask(final SchedulingPolicy policy, final ScheduledTask task) {
     final Set<ExecutorRepresenter> candidateExecutors =
         policy.filterExecutorRepresenters(getRunningExecutors(), task);
-    final Optional<ExecutorRepresenter> firstCandiate = candidateExecutors.stream().findFirst();
+    final Optional<ExecutorRepresenter> firstCandidate = candidateExecutors.stream().findFirst();
 
-    if (firstCandiate.isPresent()) {
-      final ExecutorRepresenter selectedExecutor = firstCandiate.get();
+    if (firstCandidate.isPresent()) {
+      final ExecutorRepresenter selectedExecutor = firstCandidate.get();
       selectedExecutor.onTaskScheduled(task);
       return true;
     } else {
@@ -73,15 +73,14 @@ public final class ExecutorRegistry {
     }
   }
 
-  synchronized boolean updateExecutor(
+  synchronized void updateExecutor(
       final String executorId,
       final BiFunction<ExecutorRepresenter, ExecutorState, Pair<ExecutorRepresenter, ExecutorState>> updater) {
     final Pair<ExecutorRepresenter, ExecutorState> pair = executors.get(executorId);
     if (pair == null) {
-      return false;
+      throw new IllegalArgumentException("Unknown executor id " + executorId);
     } else {
       executors.put(executorId, updater.apply(pair.left(), pair.right()));
-      return true;
     }
   }
 

--- a/runtime/master/src/main/java/edu/snu/nemo/runtime/master/scheduler/ExecutorRegistry.java
+++ b/runtime/master/src/main/java/edu/snu/nemo/runtime/master/scheduler/ExecutorRegistry.java
@@ -40,7 +40,7 @@ public final class ExecutorRegistry {
   enum ExecutorState {
     RUNNING,
     FAILED,
-    COMPLETED
+    TERMINATED
   }
 
   private final Map<String, Pair<ExecutorRepresenter, ExecutorState>> executors;
@@ -55,7 +55,6 @@ public final class ExecutorRegistry {
     if (executors.containsKey(executorId)) {
       throw new IllegalArgumentException("Duplicate executor: " + executor.toString());
     } else {
-      // System.out.println("executor registered " + executor.getExecutorId());
       executors.put(executorId, Pair.of(executor, ExecutorState.RUNNING));
     }
   }
@@ -78,7 +77,7 @@ public final class ExecutorRegistry {
   synchronized void terminate() {
     for (final ExecutorRepresenter executor : getRunningExecutors()) {
       executor.shutDown();
-      executors.put(executor.getExecutorId(), Pair.of(executor, ExecutorState.COMPLETED));
+      executors.put(executor.getExecutorId(), Pair.of(executor, ExecutorState.TERMINATED));
     }
   }
 

--- a/runtime/master/src/main/java/edu/snu/nemo/runtime/master/scheduler/PendingTaskCollection.java
+++ b/runtime/master/src/main/java/edu/snu/nemo/runtime/master/scheduler/PendingTaskCollection.java
@@ -52,11 +52,11 @@ public interface PendingTaskCollection {
   ScheduledTask remove(final String taskId) throws NoSuchElementException;
 
   /**
-   * Peeks Tasks that can be scheduled according to job dependency priority.
+   * Peeks stage that can be scheduled according to job dependency priority.
    * Changes to the queue must not reflected to the returned collection to avoid concurrent modification.
-   * @return Tasks that can be scheduled, or {@link Optional#empty()} if the queue is empty
+   * @return stage that can be scheduled, or {@link Optional#empty()} if the queue is empty
    */
-  Optional<Collection<ScheduledTask>> peekSchedulableTasks();
+  Optional<Collection<ScheduledTask>> peekSchedulableStage();
 
   /**
    * Registers a job to this queue in case the queue needs to understand the topology of the job DAG.

--- a/runtime/master/src/main/java/edu/snu/nemo/runtime/master/scheduler/Scheduler.java
+++ b/runtime/master/src/main/java/edu/snu/nemo/runtime/master/scheduler/Scheduler.java
@@ -79,8 +79,8 @@ public interface Scheduler {
    */
   void onTaskStateChanged(String executorId,
                           String taskId,
-                          TaskState.State newState,
                           int attemptIdx,
+                          TaskState.State newState,
                           @Nullable String taskPutOnHold,
                           TaskState.RecoverableFailureCause failureCause);
 

--- a/runtime/master/src/main/java/edu/snu/nemo/runtime/master/scheduler/Scheduler.java
+++ b/runtime/master/src/main/java/edu/snu/nemo/runtime/master/scheduler/Scheduler.java
@@ -27,7 +27,7 @@ import javax.annotation.Nullable;
 
 /**
  * Only two threads call scheduling code: RuntimeMaster thread (RMT), and SchedulerThread(ST).
- * RMT and ST meet only at two points: ExecutorRegistry, and PendingTaskCollection,
+ * RMT and ST meet only at two points: {@link ExecutorRegistry}, and {@link PendingTaskCollection},
  * which are synchronized(ThreadSafe).
  * Other scheduler-related classes that are accessed by only one of the two threads are not synchronized(NotThreadSafe).
  *

--- a/runtime/master/src/main/java/edu/snu/nemo/runtime/master/scheduler/Scheduler.java
+++ b/runtime/master/src/main/java/edu/snu/nemo/runtime/master/scheduler/Scheduler.java
@@ -27,7 +27,7 @@ import javax.annotation.Nullable;
 
 /**
  * Only two threads call scheduling code: RuntimeMaster thread (RMT), and SchedulerThread(ST).
- * RMT and ST meet only at two points: SchedulingPolicy, and PendingTaskCollection,
+ * RMT and ST meet only at two points: ExecutorRegistry, and PendingTaskCollection,
  * which are synchronized(ThreadSafe).
  * Other scheduler-related classes that are accessed by only one of the two threads are not synchronized(NotThreadSafe).
  *

--- a/runtime/master/src/main/java/edu/snu/nemo/runtime/master/scheduler/SchedulerRunner.java
+++ b/runtime/master/src/main/java/edu/snu/nemo/runtime/master/scheduler/SchedulerRunner.java
@@ -156,6 +156,7 @@ public final class SchedulerRunner {
 
   /**
    * A separate thread is run to schedule tasks to executors.
+   * See comments in the {@link Scheduler} for avoiding race conditions.
    */
   private final class SchedulerThread implements Runnable {
     @Override

--- a/runtime/master/src/main/java/edu/snu/nemo/runtime/master/scheduler/SchedulerRunner.java
+++ b/runtime/master/src/main/java/edu/snu/nemo/runtime/master/scheduler/SchedulerRunner.java
@@ -121,7 +121,7 @@ public final class SchedulerRunner {
       final JobStateManager jobStateManager = jobStateManagers.get(schedulableTask.getJobId());
       LOG.debug("Trying to schedule {}...", schedulableTask.getTaskId());
 
-      final boolean isScheduled = executorRegistry.registerTask(schedulingPolicy, schedulableTask);
+      final boolean isScheduled = executorRegistry.scheduleAndRegisterTask(schedulingPolicy, schedulableTask);
       if (isScheduled) {
         pendingTaskCollection.remove(schedulableTask.getTaskId());
         jobStateManager.onTaskStateChanged(schedulableTask.getTaskId(), TaskState.State.EXECUTING);

--- a/runtime/master/src/main/java/edu/snu/nemo/runtime/master/scheduler/SingleJobTaskCollection.java
+++ b/runtime/master/src/main/java/edu/snu/nemo/runtime/master/scheduler/SingleJobTaskCollection.java
@@ -31,7 +31,7 @@ import java.util.concurrent.*;
 /**
  * {@link PendingTaskCollection} implementation.
  * This class provides two-level scheduling by keeping track of schedulable stages and stage-Task membership.
- * {@link #peekSchedulableTasks()} returns collection of Tasks which belong to one of the schedulable stages.
+ * {@link #peekSchedulableStage()} returns collection of Tasks which belong to one of the schedulable stages.
  */
 @ThreadSafe
 @DriverSide
@@ -73,12 +73,12 @@ public final class SingleJobTaskCollection implements PendingTaskCollection {
 
   /**
    * Removes the specified Task to be scheduled.
-   * The specified Task should belong to the collection from {@link #peekSchedulableTasks()}.
+   * The specified Task should belong to the collection from {@link #peekSchedulableStage()}.
    * @param taskId id of the Task
    * @return the specified Task
    * @throws NoSuchElementException if the specified Task is not in the queue,
    *                                or removing this Task breaks scheduling order
-   *                                (i.e. does not belong to the collection from {@link #peekSchedulableTasks()}.
+   *                                (i.e. does not belong to the collection from {@link #peekSchedulableStage()}.
    */
   @Override
   public synchronized ScheduledTask remove(final String taskId) throws NoSuchElementException {
@@ -115,7 +115,7 @@ public final class SingleJobTaskCollection implements PendingTaskCollection {
    *         or {@link Optional#empty} if the queue is empty
    */
   @Override
-  public synchronized Optional<Collection<ScheduledTask>> peekSchedulableTasks() {
+  public synchronized Optional<Collection<ScheduledTask>> peekSchedulableStage() {
     final String stageId = schedulableStages.peekFirst();
     if (stageId == null) {
       return Optional.empty();

--- a/runtime/master/src/test/java/edu.snu.nemo.runtime.master/scheduler/BatchSingleJobSchedulerTest.java
+++ b/runtime/master/src/test/java/edu.snu.nemo.runtime.master/scheduler/BatchSingleJobSchedulerTest.java
@@ -89,7 +89,7 @@ public final class BatchSingleJobSchedulerTest {
     pubSubEventHandler = mock(PubSubEventHandlerWrapper.class);
     updatePhysicalPlanEventHandler = mock(UpdatePhysicalPlanEventHandler.class);
     scheduler =
-        new BatchSingleJobScheduler(schedulingPolicy, schedulerRunner, pendingTaskCollection,
+        new BatchSingleJobScheduler(schedulerRunner, pendingTaskCollection,
             blockManagerMaster, pubSubEventHandler, updatePhysicalPlanEventHandler, executorRegistry);
 
     final ActiveContext activeContext = mock(ActiveContext.class);

--- a/runtime/master/src/test/java/edu.snu.nemo.runtime.master/scheduler/BatchSingleJobSchedulerTest.java
+++ b/runtime/master/src/test/java/edu.snu.nemo.runtime.master/scheduler/BatchSingleJobSchedulerTest.java
@@ -74,7 +74,7 @@ public final class BatchSingleJobSchedulerTest {
   private static final int EXECUTOR_CAPACITY = 20;
 
   // Assume no failures
-  private static final int MAGIC_SCHEDULE_ATTEMPT_INDEX = 1;
+  private static final int SCHEDULE_ATTEMPT_INDEX = 1;
 
   @Before
   public void setUp() throws Exception {
@@ -164,7 +164,7 @@ public final class BatchSingleJobSchedulerTest {
 
       stages.forEach(physicalStage -> {
         SchedulerTestUtil.completeStage(
-            jobStateManager, scheduler, executorRegistry, physicalStage, MAGIC_SCHEDULE_ATTEMPT_INDEX);
+            jobStateManager, scheduler, executorRegistry, physicalStage, SCHEDULE_ATTEMPT_INDEX);
       });
     }
 

--- a/runtime/master/src/test/java/edu.snu.nemo.runtime.master/scheduler/BatchSingleJobSchedulerTest.java
+++ b/runtime/master/src/test/java/edu.snu.nemo.runtime.master/scheduler/BatchSingleJobSchedulerTest.java
@@ -73,8 +73,8 @@ public final class BatchSingleJobSchedulerTest {
 
   private static final int EXECUTOR_CAPACITY = 20;
 
-  // This schedule index will make sure that task events are not ignored
-  private static final int MAGIC_SCHEDULE_ATTEMPT_INDEX = Integer.MAX_VALUE;
+  // Assume no failures
+  private static final int MAGIC_SCHEDULE_ATTEMPT_INDEX = 1;
 
   @Before
   public void setUp() throws Exception {

--- a/runtime/master/src/test/java/edu.snu.nemo.runtime.master/scheduler/FaultToleranceTest.java
+++ b/runtime/master/src/test/java/edu.snu.nemo.runtime.master/scheduler/FaultToleranceTest.java
@@ -64,7 +64,6 @@ import static org.mockito.Mockito.mock;
     PubSubEventHandlerWrapper.class, UpdatePhysicalPlanEventHandler.class, MetricMessageHandler.class})
 public final class FaultToleranceTest {
   private static final Logger LOG = LoggerFactory.getLogger(FaultToleranceTest.class.getName());
-  private DAGBuilder<IRVertex, IREdge> irDAGBuilder;
   private Scheduler scheduler;
   private SchedulingPolicy schedulingPolicy;
   private SchedulerRunner schedulerRunner;
@@ -82,8 +81,6 @@ public final class FaultToleranceTest {
 
   @Before
   public void setUp() throws Exception {
-    irDAGBuilder = new DAGBuilder<>();
-
     metricMessageHandler = mock(MetricMessageHandler.class);
     pubSubEventHandler = mock(PubSubEventHandlerWrapper.class);
     updatePhysicalPlanEventHandler = mock(UpdatePhysicalPlanEventHandler.class);
@@ -103,9 +100,8 @@ public final class FaultToleranceTest {
     } else {
       schedulerRunner = new SchedulerRunner(schedulingPolicy, pendingTaskCollection, executorRegistry);
     }
-    scheduler =
-        new BatchSingleJobScheduler(schedulingPolicy, schedulerRunner, pendingTaskCollection,
-            blockManagerMaster, pubSubEventHandler, updatePhysicalPlanEventHandler, executorRegistry);
+    scheduler = new BatchSingleJobScheduler(schedulerRunner, pendingTaskCollection, blockManagerMaster,
+        pubSubEventHandler, updatePhysicalPlanEventHandler, executorRegistry);
 
     // Add nodes
     for (final ExecutorRepresenter executor : executors) {

--- a/runtime/master/src/test/java/edu.snu.nemo.runtime.master/scheduler/FaultToleranceTest.java
+++ b/runtime/master/src/test/java/edu.snu.nemo.runtime.master/scheduler/FaultToleranceTest.java
@@ -62,7 +62,6 @@ import static org.mockito.Mockito.mock;
 public final class FaultToleranceTest {
   private static final Logger LOG = LoggerFactory.getLogger(FaultToleranceTest.class.getName());
 
-  private Scheduler scheduler;
   private SchedulingPolicy schedulingPolicy;
   private SchedulerRunner schedulerRunner;
   private ExecutorRegistry executorRegistry;
@@ -75,7 +74,7 @@ public final class FaultToleranceTest {
   private final MessageSender<ControlMessage.Message> mockMsgSender = mock(MessageSender.class);
   private final ExecutorService serExecutorService = Executors.newSingleThreadExecutor();
 
-  private static final int MAX_SCHEDULE_ATTEMPT = 3;
+  private static final int MAX_SCHEDULE_ATTEMPT = Integer.MAX_VALUE;
 
   @Before
   public void setUp() throws Exception {
@@ -85,8 +84,7 @@ public final class FaultToleranceTest {
 
   }
 
-  private void setUpExecutors(final Collection<ExecutorRepresenter> executors,
-                              final boolean useMockSchedulerRunner) throws InjectionException {
+  private Scheduler setUpScheduler(final boolean useMockSchedulerRunner) throws InjectionException {
     final Injector injector = Tang.Factory.getTang().newInjector();
     executorRegistry = injector.getInstance(ExecutorRegistry.class);
 
@@ -98,13 +96,8 @@ public final class FaultToleranceTest {
     } else {
       schedulerRunner = new SchedulerRunner(schedulingPolicy, pendingTaskCollection, executorRegistry);
     }
-    scheduler = new BatchSingleJobScheduler(schedulerRunner, pendingTaskCollection, blockManagerMaster,
+    return new BatchSingleJobScheduler(schedulerRunner, pendingTaskCollection, blockManagerMaster,
         pubSubEventHandler, updatePhysicalPlanEventHandler, executorRegistry);
-
-    // Add nodes
-    for (final ExecutorRepresenter executor : executors) {
-      scheduler.onExecutorAdded(executor);
-    }
   }
 
   /**
@@ -127,7 +120,11 @@ public final class FaultToleranceTest {
     executors.add(a2);
     executors.add(a3);
 
-    setUpExecutors(executors, true);
+    final Scheduler scheduler = setUpScheduler(true);
+    for (final ExecutorRepresenter executor : executors) {
+      scheduler.onExecutorAdded(executor);
+    }
+
     final PhysicalPlan plan =
         TestPlanGenerator.generatePhysicalPlan(TestPlanGenerator.PlanType.TwoVerticesJoined, false);
 
@@ -195,7 +192,10 @@ public final class FaultToleranceTest {
     executors.add(a1);
     executors.add(a2);
     executors.add(a3);
-    setUpExecutors(executors, true);
+    final Scheduler scheduler = setUpScheduler(true);
+    for (final ExecutorRepresenter executor : executors) {
+      scheduler.onExecutorAdded(executor);
+    }
 
     final PhysicalPlan plan =
         TestPlanGenerator.generatePhysicalPlan(TestPlanGenerator.PlanType.TwoVerticesJoined, false);
@@ -258,7 +258,10 @@ public final class FaultToleranceTest {
     executors.add(a1);
     executors.add(a2);
     executors.add(a3);
-    setUpExecutors(executors, true);
+    final Scheduler scheduler = setUpScheduler(true);
+    for (final ExecutorRepresenter executor : executors) {
+      scheduler.onExecutorAdded(executor);
+    }
 
     final PhysicalPlan plan =
         TestPlanGenerator.generatePhysicalPlan(TestPlanGenerator.PlanType.TwoVerticesJoined, false);
@@ -304,7 +307,7 @@ public final class FaultToleranceTest {
   /**
    * Tests the rescheduling of Tasks upon a failure.
    */
-  @Test(timeout=10000)
+  @Test(timeout=20000)
   public void testTaskReexecutionForFailure() throws Exception {
     final ActiveContext activeContext = mock(ActiveContext.class);
     Mockito.doThrow(new RuntimeException()).when(activeContext).close();
@@ -312,43 +315,65 @@ public final class FaultToleranceTest {
     final ResourceSpecification computeSpec = new ResourceSpecification(ExecutorPlacementProperty.COMPUTE, 2, 0);
     final Function<String, ExecutorRepresenter> executorRepresenterGenerator = executorId ->
         new ExecutorRepresenter(executorId, computeSpec, mockMsgSender, activeContext, serExecutorService, executorId);
-    final ExecutorRepresenter a3 = executorRepresenterGenerator.apply("a3");
-    final ExecutorRepresenter a2 = executorRepresenterGenerator.apply("a2");
-    final ExecutorRepresenter a1 = executorRepresenterGenerator.apply("a1");
 
-    final List<ExecutorRepresenter> executors = new ArrayList<>();
-    executors.add(a1);
-    executors.add(a2);
-    executors.add(a3);
-
-    setUpExecutors(executors, false);
-
+    final Scheduler scheduler = setUpScheduler(false);
     final PhysicalPlan plan =
         TestPlanGenerator.generatePhysicalPlan(TestPlanGenerator.PlanType.TwoVerticesJoined, false);
-
-
     final JobStateManager jobStateManager =
         new JobStateManager(plan, blockManagerMaster, metricMessageHandler, MAX_SCHEDULE_ATTEMPT);
-
     scheduler.scheduleJob(plan, jobStateManager);
-    scheduler.onExecutorRemoved("a2");
 
+    final List<ExecutorRepresenter> executors = new ArrayList<>();
     final List<PhysicalStage> dagOf4Stages = plan.getStageDAG().getTopologicalSort();
 
+    int executorIdIndex = 1;
+    float removalChance = 0.7f; // Out of 1.0
+    final Random random = new Random(0); // Deterministic seed.
+
     for (final PhysicalStage stage : dagOf4Stages) {
+      final Map<String, Integer> taskIdToAttemptIndex = new HashMap<>();
+
       while (jobStateManager.getStageState(stage.getId()).getStateMachine().getCurrentState() != COMPLETE) {
-        final Set<String> a1RunningTasks = new HashSet<>(a1.getRunningTasks());
-        final Set<String> a3RunningTasks = new HashSet<>(a3.getRunningTasks());
+        // By chance, remove or add executor
+        if (isTrueByChance(random, removalChance)) {
+          // REMOVE EXECUTOR
+          if (!executors.isEmpty()) {
+            scheduler.onExecutorRemoved(executors.remove(random.nextInt(executors.size())).getExecutorId());
+          } else {
+            // Skip, since no executor is running.
+          }
+        } else {
+          if (executors.size() < 3) {
+            // ADD EXECUTOR
+            final ExecutorRepresenter newExecutor = executorRepresenterGenerator.apply("a" + executorIdIndex);
+            executorIdIndex += 1;
+            executors.add(newExecutor);
+            scheduler.onExecutorAdded(newExecutor);
+          } else {
+            // Skip, in order to keep the total number of running executors below or equal to 3
+          }
+        }
 
-        a1RunningTasks.forEach(taskId ->
-            SchedulerTestUtil.sendTaskStateEventToScheduler(scheduler, executorRegistry,
-                taskId, TaskState.State.COMPLETE, 1));
-
-        a3RunningTasks.forEach(taskId ->
-            SchedulerTestUtil.sendTaskStateEventToScheduler(scheduler, executorRegistry,
-                taskId, TaskState.State.COMPLETE, 1));
+        // Complete the execution of tasks
+        if (!executors.isEmpty()) {
+          final int indexOfCompletedExecutor = random.nextInt(executors.size());
+          // New set for snapshotting
+          final Set<String> runningTaskSnapshot =
+              new HashSet<>(executors.get(indexOfCompletedExecutor).getRunningTasks());
+          runningTaskSnapshot.forEach(taskId -> {
+            taskIdToAttemptIndex.putIfAbsent(taskId, 1);
+            final int attemptIndex = taskIdToAttemptIndex.get(taskId);
+            taskIdToAttemptIndex.put(taskId, attemptIndex + 1);
+            SchedulerTestUtil.sendTaskStateEventToScheduler(
+                scheduler, executorRegistry, taskId, TaskState.State.COMPLETE, attemptIndex);
+          });
+        }
       }
     }
     assertTrue(jobStateManager.checkJobTermination());
+  }
+
+  private boolean isTrueByChance(final Random random, final float chance) {
+    return chance > random.nextDouble();
   }
 }

--- a/runtime/master/src/test/java/edu.snu.nemo.runtime.master/scheduler/FaultToleranceTest.java
+++ b/runtime/master/src/test/java/edu.snu.nemo.runtime.master/scheduler/FaultToleranceTest.java
@@ -15,10 +15,7 @@
  */
 package edu.snu.nemo.runtime.master.scheduler;
 
-import edu.snu.nemo.common.dag.DAGBuilder;
 import edu.snu.nemo.common.eventhandler.PubSubEventHandlerWrapper;
-import edu.snu.nemo.common.ir.edge.IREdge;
-import edu.snu.nemo.common.ir.vertex.IRVertex;
 import edu.snu.nemo.common.ir.vertex.executionproperty.ExecutorPlacementProperty;
 import edu.snu.nemo.runtime.common.comm.ControlMessage;
 import edu.snu.nemo.runtime.common.message.MessageSender;
@@ -64,6 +61,7 @@ import static org.mockito.Mockito.mock;
     PubSubEventHandlerWrapper.class, UpdatePhysicalPlanEventHandler.class, MetricMessageHandler.class})
 public final class FaultToleranceTest {
   private static final Logger LOG = LoggerFactory.getLogger(FaultToleranceTest.class.getName());
+
   private Scheduler scheduler;
   private SchedulingPolicy schedulingPolicy;
   private SchedulerRunner schedulerRunner;

--- a/runtime/master/src/test/java/edu.snu.nemo.runtime.master/scheduler/SchedulerTestUtil.java
+++ b/runtime/master/src/test/java/edu.snu.nemo.runtime.master/scheduler/SchedulerTestUtil.java
@@ -16,19 +16,17 @@
 package edu.snu.nemo.runtime.master.scheduler;
 
 import edu.snu.nemo.runtime.common.plan.physical.PhysicalStage;
-import edu.snu.nemo.runtime.common.plan.physical.ScheduledTask;
 import edu.snu.nemo.runtime.common.state.StageState;
 import edu.snu.nemo.runtime.common.state.TaskState;
 import edu.snu.nemo.runtime.master.JobStateManager;
 import edu.snu.nemo.runtime.master.resource.ExecutorRepresenter;
 
-import java.util.Set;
-import java.util.stream.Collectors;
+import java.util.Optional;
 
 /**
  * Utility class for runtime unit tests.
  */
-public final class SchedulerTestUtil {
+final class SchedulerTestUtil {
   /**
    * Complete the stage by completing all of its Tasks.
    * @param jobStateManager for the submitted job.
@@ -36,11 +34,11 @@ public final class SchedulerTestUtil {
    * @param executorRegistry provides executor representers
    * @param physicalStage for which the states should be marked as complete.
    */
-  public static void completeStage(final JobStateManager jobStateManager,
-                                   final Scheduler scheduler,
-                                   final ExecutorRegistry executorRegistry,
-                                   final PhysicalStage physicalStage,
-                                   final int attemptIdx) {
+  static void completeStage(final JobStateManager jobStateManager,
+                            final Scheduler scheduler,
+                            final ExecutorRegistry executorRegistry,
+                            final PhysicalStage physicalStage,
+                            final int attemptIdx) {
     // Loop until the stage completes.
     while (true) {
       final Enum stageState = jobStateManager.getStageState(physicalStage.getId()).getStateMachine().getCurrentState();
@@ -76,73 +74,46 @@ public final class SchedulerTestUtil {
    * @param newState for the task.
    * @param cause in the case of a recoverable failure.
    */
-  public static void sendTaskStateEventToScheduler(final Scheduler scheduler,
-                                                   final ExecutorRegistry executorRegistry,
-                                                   final String taskId,
-                                                   final TaskState.State newState,
-                                                   final int attemptIdx,
-                                                   final TaskState.RecoverableFailureCause cause) {
-    ExecutorRepresenter scheduledExecutor;
-    do {
-      scheduledExecutor = findExecutorForTask(executorRegistry, taskId);
-    } while (scheduledExecutor == null);
-
+  static void sendTaskStateEventToScheduler(final Scheduler scheduler,
+                                            final ExecutorRegistry executorRegistry,
+                                            final String taskId,
+                                            final TaskState.State newState,
+                                            final int attemptIdx,
+                                            final TaskState.RecoverableFailureCause cause) {
+    final ExecutorRepresenter scheduledExecutor;
+    while (true) {
+      final Optional<ExecutorRepresenter> optional = executorRegistry.findExecutorForTask(taskId);
+      if (optional.isPresent()) {
+        scheduledExecutor = optional.get();
+        break;
+      }
+    }
     scheduler.onTaskStateChanged(scheduledExecutor.getExecutorId(), taskId,
         newState, attemptIdx, null, cause);
   }
 
-  public static void sendTaskStateEventToScheduler(final Scheduler scheduler,
-                                                   final ExecutorRegistry executorRegistry,
-                                                   final String taskId,
-                                                   final TaskState.State newState,
-                                                   final int attemptIdx) {
+  static void sendTaskStateEventToScheduler(final Scheduler scheduler,
+                                            final ExecutorRegistry executorRegistry,
+                                            final String taskId,
+                                            final TaskState.State newState,
+                                            final int attemptIdx) {
     sendTaskStateEventToScheduler(scheduler, executorRegistry, taskId, newState, attemptIdx, null);
   }
 
-  public static void mockSchedulerRunner(final PendingTaskCollection pendingTaskCollection,
-                                         final SchedulingPolicy schedulingPolicy,
-                                         final JobStateManager jobStateManager,
-                                         final ExecutorRegistry executorRegistry,
-                                         final boolean isPartialSchedule) {
+  static void mockSchedulerRunner(final PendingTaskCollection pendingTaskCollection,
+                                  final SchedulingPolicy schedulingPolicy,
+                                  final JobStateManager jobStateManager,
+                                  final ExecutorRegistry executorRegistry,
+                                  final boolean isPartialSchedule) {
+    final SchedulerRunner schedulerRunner =
+        new SchedulerRunner(schedulingPolicy, pendingTaskCollection, executorRegistry);
+    schedulerRunner.scheduleJob(jobStateManager);
     while (!pendingTaskCollection.isEmpty()) {
-      final ScheduledTask taskToSchedule = pendingTaskCollection.remove(
-          pendingTaskCollection.peekSchedulableTasks().get().iterator().next().getTaskId());
-
-      final Set<ExecutorRepresenter> runningExecutorRepresenter =
-          executorRegistry.getRunningExecutorIds().stream()
-              .map(executorId -> executorRegistry.getExecutorRepresenter(executorId))
-              .collect(Collectors.toSet());
-      final Set<ExecutorRepresenter> candidateExecutors =
-          schedulingPolicy.filterExecutorRepresenters(runningExecutorRepresenter, taskToSchedule);
-      if (candidateExecutors.size() > 0) {
-        jobStateManager.onTaskStateChanged(taskToSchedule.getTaskId(),
-            TaskState.State.EXECUTING);
-        final ExecutorRepresenter executor = candidateExecutors.stream().findFirst().get();
-        executor.onTaskScheduled(taskToSchedule);
-      }
-
-      // Schedule only the first task.
+      schedulerRunner.doScheduleTask();
       if (isPartialSchedule) {
+        // Schedule only the first task
         break;
       }
     }
-  }
-
-  /**
-   * Retrieves the executor to which the given task was scheduled.
-   * @param taskId of the task to search.
-   * @param executorRegistry provides executor representers
-   * @return the {@link ExecutorRepresenter} of the executor the task was scheduled to.
-   */
-  private static ExecutorRepresenter findExecutorForTask(final ExecutorRegistry executorRegistry,
-                                                         final String taskId) {
-    for (final String executorId : executorRegistry.getRunningExecutorIds()) {
-      final ExecutorRepresenter executor = executorRegistry.getRunningExecutorRepresenter(executorId);
-      if (executor.getRunningTasks().contains(taskId)
-          || executor.getCompleteTasks().contains(taskId)) {
-        return executor;
-      }
-    }
-    return null;
   }
 }

--- a/runtime/master/src/test/java/edu.snu.nemo.runtime.master/scheduler/SchedulerTestUtil.java
+++ b/runtime/master/src/test/java/edu.snu.nemo.runtime.master/scheduler/SchedulerTestUtil.java
@@ -88,8 +88,8 @@ final class SchedulerTestUtil {
         break;
       }
     }
-    scheduler.onTaskStateChanged(scheduledExecutor.getExecutorId(), taskId,
-        newState, attemptIdx, null, cause);
+    scheduler.onTaskStateChanged(scheduledExecutor.getExecutorId(), taskId, attemptIdx,
+        newState, null, cause);
   }
 
   static void sendTaskStateEventToScheduler(final Scheduler scheduler,
@@ -109,9 +109,9 @@ final class SchedulerTestUtil {
         new SchedulerRunner(schedulingPolicy, pendingTaskCollection, executorRegistry);
     schedulerRunner.scheduleJob(jobStateManager);
     while (!pendingTaskCollection.isEmpty()) {
-      schedulerRunner.doScheduleTask();
+      schedulerRunner.doScheduleStage();
       if (isPartialSchedule) {
-        // Schedule only the first task
+        // Schedule only the first stage
         break;
       }
     }

--- a/runtime/master/src/test/java/edu.snu.nemo.runtime.master/scheduler/SingleTaskQueueTest.java
+++ b/runtime/master/src/test/java/edu.snu.nemo.runtime.master/scheduler/SingleTaskQueueTest.java
@@ -231,7 +231,7 @@ public final class SingleTaskQueueTest {
    */
   private ScheduledTask dequeue() {
     final Collection<ScheduledTask> scheduledTasks
-        = pendingTaskPriorityQueue.peekSchedulableTasks().get();
+        = pendingTaskPriorityQueue.peekSchedulableStage().get();
     return pendingTaskPriorityQueue.remove(scheduledTasks.iterator().next().getTaskId());
   }
 }

--- a/tests/src/test/java/edu/snu/nemo/tests/runtime/executor/datatransfer/DataTransferTest.java
+++ b/tests/src/test/java/edu/snu/nemo/tests/runtime/executor/datatransfer/DataTransferTest.java
@@ -138,9 +138,8 @@ public final class DataTransferTest {
     final SchedulingPolicy schedulingPolicy = injector.getInstance(CompositeSchedulingPolicy.class);
     final PendingTaskCollection taskQueue = new SingleJobTaskCollection();
     final SchedulerRunner schedulerRunner = new SchedulerRunner(schedulingPolicy, taskQueue, executorRegistry);
-    final Scheduler scheduler =
-        new BatchSingleJobScheduler(schedulingPolicy, schedulerRunner, taskQueue, master,
-            pubSubEventHandler, updatePhysicalPlanEventHandler, executorRegistry);
+    final Scheduler scheduler = new BatchSingleJobScheduler(
+        schedulerRunner, taskQueue, master, pubSubEventHandler, updatePhysicalPlanEventHandler, executorRegistry);
     final AtomicInteger executorCount = new AtomicInteger(0);
 
     // Necessary for wiring up the message environments


### PR DESCRIPTION
JIRA: [NEMO-46: Make the operations on ExecutorRegistry atomic](https://issues.apache.org/jira/projects/NEMO/issues/NEMO-46)

**Major changes:**
- Make ExecutorRegistry thread-safe
- Create many failures in FaultToleranceTest#testTaskReexecutionForFailure, instead of a single failure

**Minor changes to note:**
- Track per-task attempts
- Ignore all task state change notifications from executors for previous task attempts. This can happen due to the nature of asynchronous notifications. For example, the master can receive a notification that an executor has been removed, and then a notification that the task that was running in the removed executor has been completed. In this case, if we do not look at the attempt number, the state changes from FAILED_RECOVERABLE to COMPLETED, which is illegal.
- Replace SCHEDULE_ATTEMPT_ON_CONTAINER_FAILURE = Integer.MAX_VALUE with a proper attempt index

**Tests for the changes:**
- FaultToleranceTest#testTaskReexecutionForFailure

**Other comments:**
- N/A

resolves [NEMO-46](https://issues.apache.org/jira/projects/NEMO/issues/NEMO-46)
