### PR TITLE
[NEMO-35] Controlling logging levels while running tests

### DIFF
--- a/common/src/main/resources/log4j.properties
+++ b/common/src/main/resources/log4j.properties
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-log4j.rootLogger=DEBUG, STDOUT
+log4j.rootLogger=INFO, STDOUT
 
-log4j.logger.edu.snu.nemo.runtime.master.MetricManagerMaster=DEBUG, METRIC
+log4j.logger.edu.snu.nemo.runtime.master.MetricManagerMaster=INFO, METRIC
 log4j.additivity.edu.snu.nemo.runtime.master.MetricManagerMaster=false
 
 log4j.appender.STDOUT=org.apache.log4j.ConsoleAppender


### PR DESCRIPTION
JIRA: [NEMO-35: Controlling logging levels while running tests](https://issues.apache.org/jira/projects/NEMO/issues/NEMO-35)

**Major changes:**
- Change the logging level from `DEBUG` to `INFO` in log4j.properties

**Minor changes to note:**
- N/A

**Tests for the changes:**
- N/A

**Other comments:**
- N/A

resolves [NEMO-35](https://issues.apache.org/jira/projects/NEMO/issues/NEMO-35)
