### PR TITLE
[NEMO-74] Rename RoundRobinSchedulingPolicy to MinOccupancyFirstSchedulingPolicy

### DIFF
--- a/runtime/master/src/main/java/edu/snu/nemo/runtime/master/scheduler/CompositeSchedulingPolicy.java
+++ b/runtime/master/src/main/java/edu/snu/nemo/runtime/master/scheduler/CompositeSchedulingPolicy.java
@@ -34,14 +34,14 @@ public final class CompositeSchedulingPolicy implements SchedulingPolicy {
 
   @Inject
   private CompositeSchedulingPolicy(final SourceLocationAwareSchedulingPolicy sourceLocationAwareSchedulingPolicy,
-                                    final RoundRobinSchedulingPolicy roundRobinSchedulingPolicy,
+                                    final MinOccupancyFirstSchedulingPolicy minOccupancyFirstSchedulingPolicy,
                                     final FreeSlotSchedulingPolicy freeSlotSchedulingPolicy,
                                     final ContainerTypeAwareSchedulingPolicy containerTypeAwareSchedulingPolicy) {
     schedulingPolicies = Arrays.asList(
         freeSlotSchedulingPolicy,
         containerTypeAwareSchedulingPolicy,
         sourceLocationAwareSchedulingPolicy,
-        roundRobinSchedulingPolicy);
+        minOccupancyFirstSchedulingPolicy);
   }
 
   @Override

--- a/runtime/master/src/main/java/edu/snu/nemo/runtime/master/scheduler/MinOccupancyFirstSchedulingPolicy.java
+++ b/runtime/master/src/main/java/edu/snu/nemo/runtime/master/scheduler/MinOccupancyFirstSchedulingPolicy.java
@@ -30,23 +30,22 @@ import java.util.stream.Collectors;
 
 /**
  * {@inheritDoc}
- * A Round-Robin implementation used by {@link BatchSingleJobScheduler}.
+ * A scheduling policy used by {@link BatchSingleJobScheduler}.
  *
- * This policy keeps a list of available {@link ExecutorRepresenter} for each type of container.
- * The RR policy is used for each container type when trying to schedule a task.
+ * This policy chooses a set of Executors, on which have minimum running Tasks.
  */
 @ThreadSafe
 @DriverSide
-public final class RoundRobinSchedulingPolicy implements SchedulingPolicy {
-  private static final Logger LOG = LoggerFactory.getLogger(RoundRobinSchedulingPolicy.class.getName());
+public final class MinOccupancyFirstSchedulingPolicy implements SchedulingPolicy {
+  private static final Logger LOG = LoggerFactory.getLogger(MinOccupancyFirstSchedulingPolicy.class.getName());
 
   @VisibleForTesting
   @Inject
-  public RoundRobinSchedulingPolicy() {
+  public MinOccupancyFirstSchedulingPolicy() {
   }
 
   /**
-   * @param executorRepresenterSet Set of {@link ExecutorRepresenter} to be filtered by round robin behaviour.
+   * @param executorRepresenterSet Set of {@link ExecutorRepresenter} to be filtered by the occupancy of the Executors.
    * @param task {@link Task} to be scheduled.
    * @return filtered Set of {@link ExecutorRepresenter}.
    */

--- a/runtime/master/src/main/java/edu/snu/nemo/runtime/master/scheduler/SourceLocationAwareSchedulingPolicy.java
+++ b/runtime/master/src/main/java/edu/snu/nemo/runtime/master/scheduler/SourceLocationAwareSchedulingPolicy.java
@@ -29,7 +29,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 /**
- * This policy is same as {@link RoundRobinSchedulingPolicy}, however for Tasks
+ * This policy is same as {@link MinOccupancyFirstSchedulingPolicy}, however for Tasks
  * with {@link edu.snu.nemo.common.ir.vertex.SourceVertex}, it tries to pick one of the executors
  * where the corresponding data resides.
  */

--- a/runtime/master/src/test/java/edu/snu/nemo/runtime/master/scheduler/MinOccupancyFirstSchedulingPolicyTest.java
+++ b/runtime/master/src/test/java/edu/snu/nemo/runtime/master/scheduler/MinOccupancyFirstSchedulingPolicyTest.java
@@ -29,11 +29,11 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.*;
 
 /**
- * Tests {@link RoundRobinSchedulingPolicy}
+ * Tests {@link MinOccupancyFirstSchedulingPolicy}
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ExecutorRepresenter.class, Task.class})
-public final class RoundRobinSchedulingPolicyTest {
+public final class MinOccupancyFirstSchedulingPolicyTest {
 
   private static ExecutorRepresenter mockExecutorRepresenter(final int numRunningTasks) {
     final ExecutorRepresenter executorRepresenter = mock(ExecutorRepresenter.class);
@@ -45,7 +45,7 @@ public final class RoundRobinSchedulingPolicyTest {
 
   @Test
   public void testRoundRobin() {
-    final SchedulingPolicy schedulingPolicy = new RoundRobinSchedulingPolicy();
+    final SchedulingPolicy schedulingPolicy = new MinOccupancyFirstSchedulingPolicy();
     final ExecutorRepresenter a0 = mockExecutorRepresenter(1);
     final ExecutorRepresenter a1 = mockExecutorRepresenter(2);
     final ExecutorRepresenter a2 = mockExecutorRepresenter(2);


### PR DESCRIPTION
JIRA: [NEMO-74: Rename RoundRobinSchedulingPolicy](https://issues.apache.org/jira/projects/NEMO/issues/NEMO-74)

**Major changes:**
- Rename RoundRobinSchedulingPolicy to MinOccupancyFirstSchedulingPolicy

**Minor changes to note:**
- N/A

**Tests for the changes:**
- This PR does not include tests because the changes do not affect any functionality.

**Other comments:**
- N/A

resolves [NEMO-74](https://issues.apache.org/jira/projects/NEMO/issues/NEMO-74)
