### PR TITLE
[NEMO-61] Fix lost execution metric collection problem

### DIFF
--- a/runtime/common/src/main/java/edu/snu/nemo/runtime/common/message/ncs/NcsMessageEnvironment.java
+++ b/runtime/common/src/main/java/edu/snu/nemo/runtime/common/message/ncs/NcsMessageEnvironment.java
@@ -198,6 +198,8 @@ public final class NcsMessageEnvironment implements MessageEnvironment {
       case DataSizeMetric:
       case ExecutorDataCollected:
       case MetricMessageReceived:
+      case RequestMetricFlush:
+      case MetricFlushed:
         return MessageType.Send;
       case RequestBlockLocation:
         return MessageType.Request;

--- a/runtime/common/src/main/proto/ControlMessage.proto
+++ b/runtime/common/src/main/proto/ControlMessage.proto
@@ -57,6 +57,8 @@ enum MessageType {
     ExecutorFailed = 6;
     MetricMessageReceived = 7;
     ExecutorDataCollected = 8;
+    RequestMetricFlush = 9;
+    MetricFlushed = 10;
 }
 
 message Message {

--- a/runtime/common/src/main/proto/ControlMessage.proto
+++ b/runtime/common/src/main/proto/ControlMessage.proto
@@ -55,8 +55,8 @@ enum MessageType {
     RequestBlockLocation = 4;
     BlockLocationInfo = 5;
     ExecutorFailed = 6;
-    MetricMessageReceived = 7;
-    ExecutorDataCollected = 8;
+    ExecutorDataCollected = 7;
+    MetricMessageReceived = 8;
     RequestMetricFlush = 9;
     MetricFlushed = 10;
 }

--- a/runtime/common/src/test/java/edu/snu/nemo/runtime/common/message/local/LocalMessageTest.java
+++ b/runtime/common/src/test/java/edu/snu/nemo/runtime/common/message/local/LocalMessageTest.java
@@ -19,8 +19,6 @@ import edu.snu.nemo.runtime.common.message.MessageContext;
 import edu.snu.nemo.runtime.common.message.MessageEnvironment;
 import edu.snu.nemo.runtime.common.message.MessageListener;
 import edu.snu.nemo.runtime.common.message.MessageSender;
-import edu.snu.nemo.runtime.common.message.local.LocalMessageDispatcher;
-import edu.snu.nemo.runtime.common.message.local.LocalMessageEnvironment;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/runtime/executor/src/main/java/edu/snu/nemo/runtime/executor/Executor.java
+++ b/runtime/executor/src/main/java/edu/snu/nemo/runtime/executor/Executor.java
@@ -169,16 +169,10 @@ public final class Executor {
           break;
         case RequestMetricFlush:
           metricMessageSender.flush();
-          persistentConnectionToMasterMap.getMessageSender(MessageEnvironment.RUNTIME_MASTER_MESSAGE_LISTENER_ID).send(
-              ControlMessage.Message.newBuilder()
-                  .setId(RuntimeIdGenerator.generateMessageId())
-                  .setListenerId(MessageEnvironment.RUNTIME_MASTER_MESSAGE_LISTENER_ID)
-                  .setType(ControlMessage.MessageType.MetricFlushed)
-                  .build());
           break;
-      default:
-        throw new IllegalMessageException(
-            new Exception("This message should not be received by an executor :" + message.getType()));
+        default:
+          throw new IllegalMessageException(
+              new Exception("This message should not be received by an executor :" + message.getType()));
       }
     }
 

--- a/runtime/executor/src/main/java/edu/snu/nemo/runtime/executor/MetricManagerWorker.java
+++ b/runtime/executor/src/main/java/edu/snu/nemo/runtime/executor/MetricManagerWorker.java
@@ -56,6 +56,12 @@ public final class MetricManagerWorker implements MetricMessageSender {
   @Override
   public void flush() {
     flushMetricMessageQueueToMaster();
+    persistentConnectionToMasterMap.getMessageSender(MessageEnvironment.RUNTIME_MASTER_MESSAGE_LISTENER_ID).send(
+        ControlMessage.Message.newBuilder()
+            .setId(RuntimeIdGenerator.generateMessageId())
+            .setListenerId(MessageEnvironment.RUNTIME_MASTER_MESSAGE_LISTENER_ID)
+            .setType(ControlMessage.MessageType.MetricFlushed)
+            .build());
   }
 
   private synchronized void flushMetricMessageQueueToMaster() {

--- a/runtime/executor/src/main/java/edu/snu/nemo/runtime/executor/MetricManagerWorker.java
+++ b/runtime/executor/src/main/java/edu/snu/nemo/runtime/executor/MetricManagerWorker.java
@@ -53,6 +53,10 @@ public final class MetricManagerWorker implements MetricMessageSender {
                                                       flushingPeriod, TimeUnit.MILLISECONDS);
   }
 
+  public void flush() {
+    flushMetricMessageQueueToMaster();
+  }
+
   private synchronized void flushMetricMessageQueueToMaster() {
     if (!metricMessageQueue.isEmpty()) {
       // Build batched metric messages

--- a/runtime/executor/src/main/java/edu/snu/nemo/runtime/executor/MetricManagerWorker.java
+++ b/runtime/executor/src/main/java/edu/snu/nemo/runtime/executor/MetricManagerWorker.java
@@ -53,6 +53,7 @@ public final class MetricManagerWorker implements MetricMessageSender {
                                                       flushingPeriod, TimeUnit.MILLISECONDS);
   }
 
+  @Override
   public void flush() {
     flushMetricMessageQueueToMaster();
   }

--- a/runtime/executor/src/main/java/edu/snu/nemo/runtime/executor/MetricMessageSender.java
+++ b/runtime/executor/src/main/java/edu/snu/nemo/runtime/executor/MetricMessageSender.java
@@ -25,5 +25,7 @@ public interface MetricMessageSender extends AutoCloseable {
 
   void send(final String metricKey, final String metricValue);
 
+  void flush();
+
   void close();
 }

--- a/runtime/executor/src/main/java/edu/snu/nemo/runtime/executor/MetricMessageSender.java
+++ b/runtime/executor/src/main/java/edu/snu/nemo/runtime/executor/MetricMessageSender.java
@@ -23,9 +23,20 @@ import org.apache.reef.tang.annotations.DefaultImplementation;
 @DefaultImplementation(MetricManagerWorker.class)
 public interface MetricMessageSender extends AutoCloseable {
 
+  /**
+   * Send metric to master.
+   * @param metricKey key of the metric
+   * @param metricValue value of the metric
+   */
   void send(final String metricKey, final String metricValue);
 
+  /**
+   * Flush all metric inside of the queue.
+   */
   void flush();
 
+  /**
+   * Flush the metric queue and close the metric dispatch.
+   */
   void close();
 }

--- a/runtime/executor/src/test/java/edu/snu/nemo/runtime/executor/datatransfer/DataTransferTest.java
+++ b/runtime/executor/src/test/java/edu/snu/nemo/runtime/executor/datatransfer/DataTransferTest.java
@@ -143,7 +143,7 @@ public final class DataTransferTest {
     // Necessary for wiring up the message environments
     final RuntimeMaster runtimeMaster =
         new RuntimeMaster(scheduler, containerManager, master,
-            metricMessageHandler, messageEnvironment, clientRPC, EMPTY_DAG_DIRECTORY);
+            metricMessageHandler, messageEnvironment, clientRPC, executorRegistry, EMPTY_DAG_DIRECTORY);
 
     final Injector injector1 = Tang.Factory.getTang().newInjector();
     injector1.bindVolatileInstance(MessageEnvironment.class, messageEnvironment);

--- a/runtime/executor/src/test/java/edu/snu/nemo/runtime/executor/datatransfer/DataTransferTest.java
+++ b/runtime/executor/src/test/java/edu/snu/nemo/runtime/executor/datatransfer/DataTransferTest.java
@@ -43,11 +43,8 @@ import edu.snu.nemo.runtime.executor.Executor;
 import edu.snu.nemo.runtime.executor.MetricManagerWorker;
 import edu.snu.nemo.runtime.executor.data.BlockManagerWorker;
 import edu.snu.nemo.runtime.executor.data.SerializerManager;
-import edu.snu.nemo.runtime.master.ClientRPC;
-import edu.snu.nemo.runtime.master.MetricMessageHandler;
-import edu.snu.nemo.runtime.master.BlockManagerMaster;
+import edu.snu.nemo.runtime.master.*;
 import edu.snu.nemo.runtime.master.eventhandler.UpdatePhysicalPlanEventHandler;
-import edu.snu.nemo.runtime.master.RuntimeMaster;
 import edu.snu.nemo.runtime.master.resource.ContainerManager;
 import edu.snu.nemo.runtime.master.scheduler.ExecutorRegistry;
 import edu.snu.nemo.runtime.master.scheduler.*;
@@ -91,7 +88,7 @@ import static org.mockito.Mockito.mock;
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({PubSubEventHandlerWrapper.class, UpdatePhysicalPlanEventHandler.class, MetricMessageHandler.class,
-    SourceVertex.class, ClientRPC.class})
+    SourceVertex.class, ClientRPC.class, MetricManagerMaster.class})
 public final class DataTransferTest {
   private static final String EXECUTOR_ID_PREFIX = "Executor";
   private static final InterTaskDataStoreProperty.Value MEMORY_STORE = InterTaskDataStoreProperty.Value.MemoryStore;
@@ -139,11 +136,12 @@ public final class DataTransferTest {
         schedulerRunner, taskQueue, master, pubSubEventHandler, updatePhysicalPlanEventHandler, executorRegistry);
     final AtomicInteger executorCount = new AtomicInteger(0);
     final ClientRPC clientRPC = mock(ClientRPC.class);
+    final MetricManagerMaster metricManagerMaster = mock(MetricManagerMaster.class);
 
     // Necessary for wiring up the message environments
     final RuntimeMaster runtimeMaster =
         new RuntimeMaster(scheduler, containerManager, master,
-            metricMessageHandler, messageEnvironment, clientRPC, executorRegistry, EMPTY_DAG_DIRECTORY);
+            metricMessageHandler, messageEnvironment, clientRPC, metricManagerMaster, EMPTY_DAG_DIRECTORY);
 
     final Injector injector1 = Tang.Factory.getTang().newInjector();
     injector1.bindVolatileInstance(MessageEnvironment.class, messageEnvironment);

--- a/runtime/master/src/main/java/edu/snu/nemo/runtime/master/RuntimeMaster.java
+++ b/runtime/master/src/main/java/edu/snu/nemo/runtime/master/RuntimeMaster.java
@@ -71,6 +71,7 @@ import static edu.snu.nemo.runtime.common.state.TaskState.State.ON_HOLD;
 public final class RuntimeMaster {
   private static final Logger LOG = LoggerFactory.getLogger(RuntimeMaster.class.getName());
   private static final int DAG_LOGGING_PERIOD = 3000;
+  private static final int METRIC_ARRIVE_TIMEOUT = 10000;
 
   private final ExecutorService runtimeMasterThread;
 
@@ -163,7 +164,7 @@ public final class RuntimeMaster {
 
     try {
       // wait for metric flush
-      if (!metricCountDownLatch.await(10000, TimeUnit.MILLISECONDS)) {
+      if (!metricCountDownLatch.await(METRIC_ARRIVE_TIMEOUT, TimeUnit.MILLISECONDS)) {
         LOG.warn("Terminating master before all executor terminated messages arrived.");
       }
     } catch (final InterruptedException e) {

--- a/runtime/master/src/main/java/edu/snu/nemo/runtime/master/scheduler/ExecutorRegistry.java
+++ b/runtime/master/src/main/java/edu/snu/nemo/runtime/master/scheduler/ExecutorRegistry.java
@@ -59,7 +59,7 @@ public final class ExecutorRegistry {
     }
   }
 
-  synchronized void viewExecutors(final Consumer<Set<ExecutorRepresenter>> consumer) {
+  public synchronized void viewExecutors(final Consumer<Set<ExecutorRepresenter>> consumer) {
     consumer.accept(getRunningExecutors());
   }
 

--- a/tests/src/test/java/edu/snu/nemo/runtime/master/MetricCollectionTest.java
+++ b/tests/src/test/java/edu/snu/nemo/runtime/master/MetricCollectionTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2018 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.nemo.runtime.master;
+
+import edu.snu.nemo.runtime.common.comm.ControlMessage;
+import edu.snu.nemo.runtime.common.message.MessageContext;
+import edu.snu.nemo.runtime.common.message.MessageEnvironment;
+import edu.snu.nemo.runtime.common.message.MessageListener;
+import edu.snu.nemo.runtime.common.message.MessageSender;
+import edu.snu.nemo.runtime.common.message.local.LocalMessageDispatcher;
+import edu.snu.nemo.runtime.common.message.local.LocalMessageEnvironment;
+import edu.snu.nemo.runtime.executor.MetricManagerWorker;
+import edu.snu.nemo.runtime.master.resource.ExecutorRepresenter;
+import edu.snu.nemo.runtime.master.scheduler.ExecutorRegistry;
+import org.apache.reef.tang.Configuration;
+import org.apache.reef.tang.Injector;
+import org.apache.reef.tang.Tang;
+import org.apache.reef.tang.exceptions.InjectionException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.stubbing.Answer;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Consumer;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Ensures metrics collected by {@link edu.snu.nemo.runtime.executor.MetricManagerWorker} are properly sent to master
+ * before the job finishes.
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ExecutorRepresenter.class, ExecutorRegistry.class})
+public final class MetricCollectionTest {
+  private static final Tang TANG = Tang.Factory.getTang();
+  private static final String MASTER = "MASTER";
+  private static final String WORKER = "WORKER";
+
+  @Test(timeout = 3000)
+  public void test() throws InjectionException, ExecutionException, InterruptedException {
+    final CountDownLatch latch = new CountDownLatch(1);
+
+    final LocalMessageDispatcher localMessagedispatcher = new LocalMessageDispatcher();
+
+    final Configuration configuration = TANG.newConfigurationBuilder()
+        .build();
+    final Injector injector = TANG.newInjector(configuration);
+
+    final Injector masterInjector = injector.forkInjector();
+    final Injector workerInjector = injector.forkInjector();
+
+    final LocalMessageEnvironment masterMessageEnvironment = new LocalMessageEnvironment(MASTER,
+        localMessagedispatcher);
+    masterInjector.bindVolatileInstance(MessageEnvironment.class, masterMessageEnvironment);
+
+    final LocalMessageEnvironment workerMessageEnvironment = new LocalMessageEnvironment(WORKER,
+        localMessagedispatcher);
+    workerInjector.bindVolatileInstance(MessageEnvironment.class, workerMessageEnvironment);
+
+
+    final MessageSender masterToWorkerSender = masterMessageEnvironment
+        .asyncConnect(WORKER, MessageEnvironment.EXECUTOR_MESSAGE_LISTENER_ID).get();
+    
+    final ExecutorRepresenter workerRepresenter = mock(ExecutorRepresenter.class);
+    doAnswer((Answer<Void>) invocationOnMock -> {
+      final ControlMessage.Message msg = (ControlMessage.Message) invocationOnMock.getArguments()[0];
+      masterToWorkerSender.send(msg);
+      return null;
+    }).when(workerRepresenter).sendControlMessage(any());
+
+    final ExecutorRegistry executorRegistry = mock(ExecutorRegistry.class);
+    doAnswer((Answer<Void>) invocationOnMock -> {
+      final Consumer<Set<ExecutorRepresenter>> consumer = (Consumer) invocationOnMock.getArguments()[0];
+      consumer.accept(Collections.singleton(workerRepresenter));
+      return null;
+    }).when(executorRegistry).viewExecutors(any());
+
+    masterInjector.bindVolatileInstance(ExecutorRegistry.class, executorRegistry);
+
+    final MetricManagerMaster metricManagerMaster = masterInjector.getInstance(MetricManagerMaster.class);
+    final MetricManagerWorker metricManagerWorker = workerInjector.getInstance(MetricManagerWorker.class);
+
+    masterMessageEnvironment.setupListener(MessageEnvironment.RUNTIME_MASTER_MESSAGE_LISTENER_ID,
+        new MessageListener<Object>() {
+        @Override
+        public void onMessage(Object message) {
+          System.out.println(message);
+          latch.countDown();
+        }
+
+        @Override
+        public void onMessageWithContext(Object message, MessageContext messageContext) {
+        }
+    });
+
+    workerMessageEnvironment.setupListener(MessageEnvironment.EXECUTOR_MESSAGE_LISTENER_ID,
+        new MessageListener<Object>() {
+          @Override
+          public void onMessage(Object message) {
+            metricManagerWorker.flush();
+          }
+
+          @Override
+          public void onMessageWithContext(Object message, MessageContext messageContext) {
+          }
+        });
+
+    metricManagerWorker.send("HEHE", "HOHO");
+    metricManagerMaster.sendMetricFlushRequest();
+
+    latch.await();
+  }
+}


### PR DESCRIPTION
JIRA: [NEMO-61: Fix lost execution metric collection problem](https://issues.apache.org/jira/projects/NEMO/issues/NEMO-61)

**Major changes:**
- Add metric flush request and response types in control message type.
- `RuntimeMaster#terminate` now wait until all metrics from executors arrive.

**Minor changes to note:**
- Expose `ExecutorReqistry#viewExecutors` to public.

**Tests for the changes:**
- MetricFlushTest ensures MetricManagerMaster can send flush requests to MetricManagerWorkers and workers respond appropriately by flushing remaining metric logs.

**Other comments:**
- Related to NEMO-20.

resolves [NEMO-61](https://issues.apache.org/jira/projects/NEMO/issues/NEMO-61)
