### PR TITLE
[NEMO-163] Update README.md to use Hadoop 2.7.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ Please refer to the [Contribution guideline](.github/CONTRIBUTING.md) to contrib
 * Java 8
 * Maven
 * YARN settings
-    * Download Hadoop 2.7.4 at https://archive.apache.org/dist/hadoop/common/hadoop-2.7.4/
+    * Download Hadoop 2.7.2 at https://archive.apache.org/dist/hadoop/common/hadoop-2.7.2/
     * Set the shell profile as following:
         ```bash
-        export HADOOP_HOME=/path/to/hadoop-2.7.4
+        export HADOOP_HOME=/path/to/hadoop-2.7.2
         export YARN_HOME=$HADOOP_HOME
         export PATH=$PATH:$HADOOP_HOME/bin
         ```


### PR DESCRIPTION
JIRA: [NEMO-163: Update README.md to use Hadoop 2.7.2](https://issues.apache.org/jira/projects/NEMO/issues/NEMO-163)

**Major changes:**
- N/A

**Minor changes to note:**
- Updated README.md to use Hadoop 2.7.2.

**Tests for the changes:**
- N/A

**Other comments:**
- Some features of Nemo won't be available under Hadoop 2.7.2. Since the REEF implementation we depend on uses Hadoop 2.7.2, we'd better update README for newcomers to use Hadoop 2.7.2.

resolves [NEMO-163](https://issues.apache.org/jira/projects/NEMO/issues/NEMO-163)
