### PR TITLE
[NEMO-165] Bug when a task reads from multiple parent tasks

### DIFF
--- a/runtime/executor/src/main/java/edu/snu/nemo/runtime/executor/task/TaskExecutor.java
+++ b/runtime/executor/src/main/java/edu/snu/nemo/runtime/executor/task/TaskExecutor.java
@@ -350,8 +350,9 @@ public final class TaskExecutor {
    */
   private boolean handleDataFetchers(final List<DataFetcher> fetchers) {
     final List<DataFetcher> availableFetchers = new ArrayList<>(fetchers);
-    int finishedFetcherIndex = NONE_FINISHED;
     while (!availableFetchers.isEmpty()) { // empty means we've consumed all task-external input data
+      // For this looping of available fetchers.
+      int finishedFetcherIndex = NONE_FINISHED;
       for (int i = 0; i < availableFetchers.size(); i++) {
         final DataFetcher dataFetcher = fetchers.get(i);
         final Object element;


### PR DESCRIPTION
JIRA: [NEMO-165: Bug when a task reads from multiple parent tasks](https://issues.apache.org/jira/projects/NEMO/issues/NEMO-165)

**Major changes:**
- In TaskExecutor#handleDataFetchers, initialize "int finishedFetcherIndex" in each looping, and not outside the loop.

**Minor changes to note:**
- N/A

**Tests for the changes:**
- N/A

**Other comments:**
- N/A

resolves [NEMO-165](https://issues.apache.org/jira/projects/NEMO/issues/NEMO-165)
