### PR TITLE
[NEMO-166] Do not attach NodeNamesProperty to Source Stages

### DIFF
--- a/compiler/optimizer/src/main/java/edu/snu/nemo/compiler/optimizer/pass/compiletime/annotating/NodeNamesAssignmentPass.java
+++ b/compiler/optimizer/src/main/java/edu/snu/nemo/compiler/optimizer/pass/compiletime/annotating/NodeNamesAssignmentPass.java
@@ -102,10 +102,11 @@ public final class NodeNamesAssignmentPass extends AnnotatingPass {
         }
         irVertex.getExecutionProperties().put(NodeNamesProperty.of(shares));
       } else if (isOneToOneEdge(inEdges)) {
-        LOG.info(String.format("Setting %s - is o2o from %s", irVertex.getId(), inEdges.iterator().next()));
-        final Optional<NodeNamesProperty> property = inEdges.iterator().next()
+        LOG.info(String.format("Setting %s - is o2o from %s", irVertex.getId(),
+            inEdges.iterator().next().getSrc().getId()));
+        final Optional<HashMap<String, Integer>> property = inEdges.iterator().next()
             .getExecutionProperties().get(NodeNamesProperty.class);
-        irVertex.getExecutionProperties().put(property.get());
+        irVertex.getExecutionProperties().put(NodeNamesProperty.of(property.get()));
       } else {
         LOG.info(String.format("Setting %s - is complex", irVertex.getId()));
         // This IRVertex has shuffle inEdge(s), or has multiple inEdges.

--- a/compiler/optimizer/src/main/java/edu/snu/nemo/compiler/optimizer/pass/compiletime/annotating/NodeNamesAssignmentPass.java
+++ b/compiler/optimizer/src/main/java/edu/snu/nemo/compiler/optimizer/pass/compiletime/annotating/NodeNamesAssignmentPass.java
@@ -81,6 +81,16 @@ public final class NodeNamesAssignmentPass extends AnnotatingPass {
     bandwidthSpecificationString = value;
   }
 
+  private static HashMap<String, Integer> getEvenShares(final List<String> nodes, final int parallelism) {
+    final HashMap<String, Integer> shares = new HashMap<>();
+    final int defaultShare = parallelism / nodes.size();
+    final int remainder = parallelism % nodes.size();
+    for (int i = 0; i < nodes.size(); i++) {
+      shares.put(nodes.get(i), defaultShare + (i < remainder ? 1 : 0));
+    }
+    return shares;
+  }
+
   private static void assignNodeShares(
       final DAG<IRVertex, IREdge> dag,
       final BandwidthSpecification bandwidthSpecification) {
@@ -93,14 +103,7 @@ public final class NodeNamesAssignmentPass extends AnnotatingPass {
         LOG.info(String.format("Setting %s - is root", irVertex.getId()));
         // This vertex is root vertex.
         // Fall back to setting even distribution
-        final HashMap<String, Integer> shares = new HashMap<>();
-        final List<String> nodes = bandwidthSpecification.getNodes();
-        final int defaultShare = parallelism / nodes.size();
-        final int remainder = parallelism % nodes.size();
-        for (int i = 0; i < nodes.size(); i++) {
-          shares.put(nodes.get(i), defaultShare + (i < remainder ? 1 : 0));
-        }
-        irVertex.getExecutionProperties().put(NodeNamesProperty.of(shares));
+        irVertex.getExecutionProperties().put(NodeNamesProperty.of(EMPTY_MAP));
       } else if (isOneToOneEdge(inEdges)) {
         LOG.info(String.format("Setting %s - is o2o from %s", irVertex.getId(),
             inEdges.iterator().next().getSrc().getId()));
@@ -113,7 +116,11 @@ public final class NodeNamesAssignmentPass extends AnnotatingPass {
         final Map<String, Integer> parentLocationShares = new HashMap<>();
         for (final IREdge edgeToIRVertex : dag.getIncomingEdgesOf(irVertex)) {
           final IRVertex parentVertex = edgeToIRVertex.getSrc();
-          final Map<String, Integer> shares = parentVertex.getPropertyValue(NodeNamesProperty.class).get();
+          final Map<String, Integer> parentShares = parentVertex.getPropertyValue(NodeNamesProperty.class).get();
+          final int parentParallelism = parentVertex.getPropertyValue(ParallelismProperty.class)
+              .orElseThrow(() -> new RuntimeException("Parallelism property required"));
+          final Map<String, Integer> shares = parentShares.isEmpty() ? getEvenShares(bandwidthSpecification.getNodes(),
+              parentParallelism) : parentShares;
           for (final Map.Entry<String, Integer> element : shares.entrySet()) {
             parentLocationShares.putIfAbsent(element.getKey(), 0);
             parentLocationShares.put(element.getKey(),

--- a/compiler/optimizer/src/main/java/edu/snu/nemo/compiler/optimizer/pass/compiletime/annotating/NodeNamesAssignmentPass.java
+++ b/compiler/optimizer/src/main/java/edu/snu/nemo/compiler/optimizer/pass/compiletime/annotating/NodeNamesAssignmentPass.java
@@ -103,7 +103,6 @@ public final class NodeNamesAssignmentPass extends AnnotatingPass {
         // Fall back to setting even distribution
         irVertex.getExecutionProperties().put(NodeNamesProperty.of(EMPTY_MAP));
       } else if (isOneToOneEdge(inEdges)) {
-            inEdges.iterator().next().getSrc().getId()));
         final Optional<HashMap<String, Integer>> property = inEdges.iterator().next().getSrc()
             .getExecutionProperties().get(NodeNamesProperty.class);
         irVertex.getExecutionProperties().put(NodeNamesProperty.of(property.get()));

--- a/compiler/optimizer/src/main/java/edu/snu/nemo/compiler/optimizer/pass/compiletime/annotating/NodeNamesAssignmentPass.java
+++ b/compiler/optimizer/src/main/java/edu/snu/nemo/compiler/optimizer/pass/compiletime/annotating/NodeNamesAssignmentPass.java
@@ -104,7 +104,7 @@ public final class NodeNamesAssignmentPass extends AnnotatingPass {
       } else if (isOneToOneEdge(inEdges)) {
         LOG.info(String.format("Setting %s - is o2o from %s", irVertex.getId(),
             inEdges.iterator().next().getSrc().getId()));
-        final Optional<HashMap<String, Integer>> property = inEdges.iterator().next()
+        final Optional<HashMap<String, Integer>> property = inEdges.iterator().next().getSrc()
             .getExecutionProperties().get(NodeNamesProperty.class);
         irVertex.getExecutionProperties().put(NodeNamesProperty.of(property.get()));
       } else {

--- a/compiler/optimizer/src/main/java/edu/snu/nemo/compiler/optimizer/pass/compiletime/annotating/NodeNamesAssignmentPass.java
+++ b/compiler/optimizer/src/main/java/edu/snu/nemo/compiler/optimizer/pass/compiletime/annotating/NodeNamesAssignmentPass.java
@@ -95,23 +95,19 @@ public final class NodeNamesAssignmentPass extends AnnotatingPass {
       final DAG<IRVertex, IREdge> dag,
       final BandwidthSpecification bandwidthSpecification) {
     dag.topologicalDo(irVertex -> {
-      LOG.info(String.format("Setting %s", irVertex.getId()));
       final Collection<IREdge> inEdges = dag.getIncomingEdgesOf(irVertex);
       final int parallelism = irVertex.getPropertyValue(ParallelismProperty.class)
           .orElseThrow(() -> new RuntimeException("Parallelism property required"));
       if (inEdges.size() == 0) {
-        LOG.info(String.format("Setting %s - is root", irVertex.getId()));
         // This vertex is root vertex.
         // Fall back to setting even distribution
         irVertex.getExecutionProperties().put(NodeNamesProperty.of(EMPTY_MAP));
       } else if (isOneToOneEdge(inEdges)) {
-        LOG.info(String.format("Setting %s - is o2o from %s", irVertex.getId(),
             inEdges.iterator().next().getSrc().getId()));
         final Optional<HashMap<String, Integer>> property = inEdges.iterator().next().getSrc()
             .getExecutionProperties().get(NodeNamesProperty.class);
         irVertex.getExecutionProperties().put(NodeNamesProperty.of(property.get()));
       } else {
-        LOG.info(String.format("Setting %s - is complex", irVertex.getId()));
         // This IRVertex has shuffle inEdge(s), or has multiple inEdges.
         final Map<String, Integer> parentLocationShares = new HashMap<>();
         for (final IREdge edgeToIRVertex : dag.getIncomingEdgesOf(irVertex)) {

--- a/runtime/master/src/main/java/edu/snu/nemo/runtime/master/scheduler/NodeShareSchedulingConstraint.java
+++ b/runtime/master/src/main/java/edu/snu/nemo/runtime/master/scheduler/NodeShareSchedulingConstraint.java
@@ -55,7 +55,11 @@ public final class NodeShareSchedulingConstraint implements SchedulingConstraint
     if (propertyValue.isEmpty()) {
       return true;
     }
-    return executor.getNodeName().equals(
-        getNodeName(propertyValue, RuntimeIdGenerator.getIndexFromTaskId(task.getTaskId())));
+    try {
+      return executor.getNodeName().equals(
+          getNodeName(propertyValue, RuntimeIdGenerator.getIndexFromTaskId(task.getTaskId())));
+    } catch (final IllegalStateException e) {
+      throw new RuntimeException(String.format("Cannot schedule %s", task.getTaskId(), e));
+    }
   }
 }

--- a/runtime/master/src/main/java/edu/snu/nemo/runtime/master/scheduler/NodeShareSchedulingConstraint.java
+++ b/runtime/master/src/main/java/edu/snu/nemo/runtime/master/scheduler/NodeShareSchedulingConstraint.java
@@ -39,7 +39,7 @@ public final class NodeShareSchedulingConstraint implements SchedulingConstraint
     Collections.sort(nodeNames, Comparator.naturalOrder());
     int index = taskIndex;
     for (final String nodeName : nodeNames) {
-      if (index < propertyValue.get(nodeName)) {
+      if (index >= propertyValue.get(nodeName)) {
         index -= propertyValue.get(nodeName);
       } else {
         return nodeName;


### PR DESCRIPTION
JIRA: [NEMO-166: Do not attach NodeNamesProperty to Source Stages](https://issues.apache.org/jira/projects/NEMO/issues/NEMO-166)

**Major changes:**
- Attaching NodeNamesProperty to source stages makes scheduling source tasks virtually impossible, if the assigned node does not have the corresponding source split. This PR prevents NodeNameAssignmentPass not to assign node names on source stages.

**Minor changes to note:**
- N/A

**Tests for the changes:**
- N/A

**Other comments:**
- Integration tests on distributed environment is desired.

resolves [NEMO-166](https://issues.apache.org/jira/projects/NEMO/issues/NEMO-166)
