### PR TITLE
[NEMO-176] Improve sequential read from disk

### DIFF
--- a/runtime/executor/src/main/java/edu/snu/nemo/runtime/executor/datatransfer/InputReader.java
+++ b/runtime/executor/src/main/java/edu/snu/nemo/runtime/executor/datatransfer/InputReader.java
@@ -170,13 +170,8 @@ public final class InputReader extends DataTransfer {
    * @return the parallelism of the source task.
    */
   public int getSourceParallelism() {
-    if (CommunicationPatternProperty.Value.OneToOne
-        .equals(runtimeEdge.getPropertyValue(CommunicationPatternProperty.class).get())) {
-      return 1;
-    } else {
-      final Integer numSrcTasks = srcVertex.getPropertyValue(ParallelismProperty.class).get();
-      return numSrcTasks;
-    }
+    return srcVertex.getPropertyValue(ParallelismProperty.class).
+        orElseThrow(() -> new RuntimeException("No parallelism property on this edge."));
   }
 
   /**

--- a/runtime/executor/src/main/java/edu/snu/nemo/runtime/executor/datatransfer/OutputWriter.java
+++ b/runtime/executor/src/main/java/edu/snu/nemo/runtime/executor/datatransfer/OutputWriter.java
@@ -65,22 +65,28 @@ public final class OutputWriter extends DataTransfer implements AutoCloseable {
     this.srcVertexId = srcRuntimeVertexId;
     this.dstIrVertex = dstIrVertex;
     this.blockManagerWorker = blockManagerWorker;
-    this.blockStoreValue = runtimeEdge.getPropertyValue(DataStoreProperty.class).get();
+    this.blockStoreValue = runtimeEdge.getPropertyValue(DataStoreProperty.class).
+        orElseThrow(() -> new RuntimeException("No data store property on the edge"));
+
 
     // Setup partitioner
-    final int dstParallelism = getDstParallelism();
+    final int dstParallelism = dstIrVertex.getPropertyValue(ParallelismProperty.class).
+        orElseThrow(() -> new RuntimeException("No parallelism property on the destination vertex"));
     final Optional<KeyExtractor> keyExtractor = runtimeEdge.getPropertyValue(KeyExtractorProperty.class);
     final PartitionerProperty.Value partitionerPropertyValue =
-        runtimeEdge.getPropertyValue(PartitionerProperty.class).get();
+        runtimeEdge.getPropertyValue(PartitionerProperty.class).
+            orElseThrow(() -> new RuntimeException("No partitioner property on the edge"));
     switch (partitionerPropertyValue) {
       case IntactPartitioner:
         this.partitioner = new IntactPartitioner();
         break;
       case HashPartitioner:
-        this.partitioner = new HashPartitioner(dstParallelism, keyExtractor.get());
+        this.partitioner = new HashPartitioner(dstParallelism, keyExtractor.
+            orElseThrow(() -> new RuntimeException("No key extractor property on the edge")));
         break;
       case DataSkewHashPartitioner:
-        this.partitioner = new DataSkewHashPartitioner(hashRangeMultiplier, dstParallelism, keyExtractor.get());
+        this.partitioner = new DataSkewHashPartitioner(hashRangeMultiplier, dstParallelism, keyExtractor.
+            orElseThrow(() -> new RuntimeException("No key extractor property on the edge")));
         break;
       case DedicatedKeyPerElementPartitioner:
         this.partitioner = new DedicatedKeyPerElementPartitioner();
@@ -122,10 +128,8 @@ public final class OutputWriter extends DataTransfer implements AutoCloseable {
   public void close() {
     // Commit block.
     final DataPersistenceProperty.Value persistence =
-        runtimeEdge.getPropertyValue(DataPersistenceProperty.class).get();
-    final Optional<DuplicateEdgeGroupPropertyValue> duplicateDataProperty =
-        runtimeEdge.getPropertyValue(DuplicateEdgeGroupProperty.class);
-    final int multiplier = duplicateDataProperty.isPresent() ? duplicateDataProperty.get().getGroupSize() : 1;
+        runtimeEdge.getPropertyValue(DataPersistenceProperty.class).
+            orElseThrow(() -> new RuntimeException("No data persistence property on the edge"));
 
     final boolean isDataSizeMetricCollectionEdge = Optional.of(MetricCollectionProperty.Value.DataSkewRuntimePass)
         .equals(runtimeEdge.getPropertyValue(MetricCollectionProperty.class));
@@ -138,11 +142,11 @@ public final class OutputWriter extends DataTransfer implements AutoCloseable {
       }
       this.writtenBytes = blockSizeTotal;
       blockManagerWorker.writeBlock(blockToWrite, blockStoreValue, isDataSizeMetricCollectionEdge,
-          partitionSizeMap.get(), srcVertexId, getDstParallelism() * multiplier, persistence);
+          partitionSizeMap.get(), srcVertexId, getExpectedRead(), persistence);
     } else {
       this.writtenBytes = -1; // no written bytes info.
       blockManagerWorker.writeBlock(blockToWrite, blockStoreValue, isDataSizeMetricCollectionEdge,
-          Collections.emptyMap(), srcVertexId, getDstParallelism() * multiplier, persistence);
+          Collections.emptyMap(), srcVertexId, getExpectedRead(), persistence);
     }
   }
 
@@ -158,13 +162,21 @@ public final class OutputWriter extends DataTransfer implements AutoCloseable {
   }
 
   /**
-   * Get the parallelism of the destination task.
+   * Get the expected number of data read according to the communication pattern of the edge and
+   * the parallelism of destination vertex.
    *
-   * @return the parallelism of the destination task.
+   * @return the expected number of data read.
    */
-  private int getDstParallelism() {
-    return CommunicationPatternProperty.Value.OneToOne.equals(
-        runtimeEdge.getPropertyValue(CommunicationPatternProperty.class).get())
-        ? 1 : dstIrVertex.getPropertyValue(ParallelismProperty.class).get();
+  private int getExpectedRead() {
+    final Optional<DuplicateEdgeGroupPropertyValue> duplicateDataProperty =
+        runtimeEdge.getPropertyValue(DuplicateEdgeGroupProperty.class);
+    final int duplicatedDataMultiplier =
+        duplicateDataProperty.isPresent() ? duplicateDataProperty.get().getGroupSize() : 1;
+    final int readForABlock = CommunicationPatternProperty.Value.OneToOne.equals(
+        runtimeEdge.getPropertyValue(CommunicationPatternProperty.class).orElseThrow(
+            () -> new RuntimeException("No communication pattern on this edge.")))
+        ? 1 : dstIrVertex.getPropertyValue(ParallelismProperty.class).orElseThrow(
+            () -> new RuntimeException("No parallelism property on the destination vertex."));
+    return readForABlock * duplicatedDataMultiplier;
   }
 }

--- a/runtime/executor/src/test/java/edu/snu/nemo/runtime/executor/datatransfer/DataTransferTest.java
+++ b/runtime/executor/src/test/java/edu/snu/nemo/runtime/executor/datatransfer/DataTransferTest.java
@@ -334,11 +334,7 @@ public final class DataTransferTest {
       final InputReader reader =
           new InputReader(dstTaskIndex, srcVertex, dummyEdge, receiver);
 
-      if (CommunicationPatternProperty.Value.OneToOne.equals(commPattern)) {
-        assertEquals(1, reader.getSourceParallelism());
-      } else {
-        assertEquals(PARALLELISM_TEN, reader.getSourceParallelism());
-      }
+      assertEquals(PARALLELISM_TEN, reader.getSourceParallelism());
 
       final List dataRead = new ArrayList<>();
       try {
@@ -436,17 +432,9 @@ public final class DataTransferTest {
       final InputReader reader2 =
           new InputReader(dstTaskIndex, srcVertex, dummyEdge2, receiver);
 
-      if (CommunicationPatternProperty.Value.OneToOne.equals(commPattern)) {
-        assertEquals(1, reader.getSourceParallelism());
-      } else {
-        assertEquals(PARALLELISM_TEN, reader.getSourceParallelism());
-      }
+      assertEquals(PARALLELISM_TEN, reader.getSourceParallelism());
 
-      if (CommunicationPatternProperty.Value.OneToOne.equals(commPattern)) {
-        assertEquals(1, reader2.getSourceParallelism());
-      } else {
-        assertEquals(PARALLELISM_TEN, reader2.getSourceParallelism());
-      }
+      assertEquals(PARALLELISM_TEN, reader2.getSourceParallelism());
 
       final List dataRead = new ArrayList<>();
       try {


### PR DESCRIPTION
JIRA: [NEMO-176: Improve sequential read from disk](https://issues.apache.org/jira/projects/NEMO/issues/NEMO-176)

**Major changes:**
- Read whole data to read from file stream first and decode them later in `FileBlock`

**Minor changes to note:**
- Remove `limit` parameter in `InputStreamIterator` of `DataUtil` and make `DataUtil#deserializePartition` to limit the stream itself by the partition size.
- Remove the assumption that "the source and destination parallelism of One-to-One communication is always 1" in `OutputWriter` and `InputReader`

**Tests for the changes:**
- Existing `DataTransferTest`, `BlockStoreTest` and other unit tests cover this change.
- Existing integration tests also cover this change.

**Other comments:**
- N/A.

resolves [NEMO-176](https://issues.apache.org/jira/projects/NEMO/issues/NEMO-176)
