### PR TITLE
[NEMO-160] Handle Beam VoidCoder properly

### DIFF
--- a/runtime/executor/src/main/java/edu/snu/nemo/runtime/executor/datatransfer/OutputCollectorImpl.java
+++ b/runtime/executor/src/main/java/edu/snu/nemo/runtime/executor/datatransfer/OutputCollectorImpl.java
@@ -25,60 +25,61 @@ import java.util.*;
  * @param <O> output type.
  */
 public final class OutputCollectorImpl<O> implements OutputCollector<O> {
-  private final ArrayList<O> mainTagOutputQueue; // Use ArrayList to allow 'null' values
-  private final Map<String, ArrayList<Object>> additionalTagOutputQueues; // Use ArrayList to allow 'null' values
+  // Use ArrayList (not Queue) to allow 'null' values
+  private final ArrayList<O> mainTagElements;
+  private final Map<String, ArrayList<Object>> additionalTagElementsMap;
 
   /**
    * Constructor of a new OutputCollectorImpl with tagged outputs.
    * @param taggedChildren tagged children
    */
   public OutputCollectorImpl(final List<String> taggedChildren) {
-    this.mainTagOutputQueue = new ArrayList<>(1);
-    this.additionalTagOutputQueues = new HashMap<>();
-    taggedChildren.forEach(child -> this.additionalTagOutputQueues.put(child, new ArrayList<>(1)));
+    this.mainTagElements = new ArrayList<>(1);
+    this.additionalTagElementsMap = new HashMap<>();
+    taggedChildren.forEach(child -> this.additionalTagElementsMap.put(child, new ArrayList<>(1)));
   }
 
   @Override
   public void emit(final O output) {
-    mainTagOutputQueue.add(output);
+    mainTagElements.add(output);
   }
 
   @Override
   public <T> void emit(final String dstVertexId, final T output) {
-    if (this.additionalTagOutputQueues.get(dstVertexId) == null) {
+    if (this.additionalTagElementsMap.get(dstVertexId) == null) {
       // This dstVertexId is for the main tag
       emit((O) output);
     } else {
       // Note that String#hashCode() can be cached, thus accessing additional output queues can be fast.
-      this.additionalTagOutputQueues.get(dstVertexId).add(output);
+      this.additionalTagElementsMap.get(dstVertexId).add(output);
     }
   }
 
   public Iterable<O> iterateMain() {
-    return mainTagOutputQueue;
+    return mainTagElements;
   }
 
   public Iterable<Object> iterateTag(final String tag) {
-    if (this.additionalTagOutputQueues.get(tag) == null) {
+    if (this.additionalTagElementsMap.get(tag) == null) {
       // This dstVertexId is for the main tag
       return (Iterable<Object>) iterateMain();
     } else {
       // Note that String#hashCode() can be cached, thus accessing additional output queues can be fast.
-      return this.additionalTagOutputQueues.get(tag);
+      return this.additionalTagElementsMap.get(tag);
     }
   }
 
   public void clearMain() {
-    mainTagOutputQueue.clear();
+    mainTagElements.clear();
   }
 
   public void clearTag(final String tag) {
-    if (this.additionalTagOutputQueues.get(tag) == null) {
+    if (this.additionalTagElementsMap.get(tag) == null) {
       // This dstVertexId is for the main tag
       clearMain();
     } else {
       // Note that String#hashCode() can be cached, thus accessing additional output queues can be fast.
-      this.additionalTagOutputQueues.get(tag).clear();
+      this.additionalTagElementsMap.get(tag).clear();
     }
   }
 }

--- a/runtime/executor/src/main/java/edu/snu/nemo/runtime/executor/datatransfer/OutputCollectorImpl.java
+++ b/runtime/executor/src/main/java/edu/snu/nemo/runtime/executor/datatransfer/OutputCollectorImpl.java
@@ -29,6 +29,10 @@ import java.util.Queue;
  * @param <O> output type.
  */
 public final class OutputCollectorImpl<O> implements OutputCollector<O> {
+  // This is necessary to handle 'null' data elements emitted by user operators.
+  // ArrayDequeue does not allow 'null' elements, so we use this NULL_REPRESENTER instead.
+  private static final Object NULL_REPRESENTER = new Object();
+
   private final Queue<O> mainTagOutputQueue;
   private final Map<String, Queue<Object>> additionalTagOutputQueues;
 

--- a/runtime/executor/src/main/java/edu/snu/nemo/runtime/executor/datatransfer/OutputCollectorImpl.java
+++ b/runtime/executor/src/main/java/edu/snu/nemo/runtime/executor/datatransfer/OutputCollectorImpl.java
@@ -29,19 +29,11 @@ public final class OutputCollectorImpl<O> implements OutputCollector<O> {
   private final Map<String, ArrayList<Object>> additionalTagOutputQueues; // Use ArrayList to allow 'null' values
 
   /**
-   * Constructor of a new OutputCollectorImpl.
-   */
-  public OutputCollectorImpl() {
-    this.mainTagOutputQueue = new ArrayList<>();
-    this.additionalTagOutputQueues = new HashMap<>();
-  }
-
-  /**
    * Constructor of a new OutputCollectorImpl with tagged outputs.
    * @param taggedChildren tagged children
    */
   public OutputCollectorImpl(final List<String> taggedChildren) {
-    this.mainTagOutputQueue = new ArrayList<>();
+    this.mainTagOutputQueue = new ArrayList<>(1);
     this.additionalTagOutputQueues = new HashMap<>();
     taggedChildren.forEach(child -> this.additionalTagOutputQueues.put(child, new ArrayList<>(1)));
   }

--- a/runtime/executor/src/main/java/edu/snu/nemo/runtime/executor/task/DataFetcher.java
+++ b/runtime/executor/src/main/java/edu/snu/nemo/runtime/executor/task/DataFetcher.java
@@ -17,8 +17,6 @@ package edu.snu.nemo.runtime.executor.task;
 
 import edu.snu.nemo.common.ir.vertex.IRVertex;
 
-import java.io.IOException;
-
 /**
  * An abstraction for fetching data from task-external sources.
  */
@@ -38,11 +36,13 @@ abstract class DataFetcher {
     this.isFromSideInput = isFromSideInput;
   }
 
-  // Can block.
-  abstract boolean hasNext();
-
-  // Can block.
-  abstract Object next();
+  /**
+   * This call can block.
+   * @return data element
+   * @throws java.util.NoSuchElementException if no more element is available
+   * @throws RuntimeException if an I/O error occurs during fetching
+   */
+  abstract Object fetchDataElement();
 
   VertexHarness getChild() {
     return child;

--- a/runtime/executor/src/main/java/edu/snu/nemo/runtime/executor/task/DataFetcher.java
+++ b/runtime/executor/src/main/java/edu/snu/nemo/runtime/executor/task/DataFetcher.java
@@ -38,13 +38,11 @@ abstract class DataFetcher {
     this.isFromSideInput = isFromSideInput;
   }
 
-  /**
-   * Can block until the next data element becomes available.
-   *
-   * @return null if there's no more data element.
-   * @throws IOException while fetching data
-   */
-  abstract Object fetchDataElement() throws IOException;
+  // Can block.
+  abstract boolean hasNext();
+
+  // Can block.
+  abstract Object next();
 
   VertexHarness getChild() {
     return child;

--- a/runtime/executor/src/main/java/edu/snu/nemo/runtime/executor/task/DataFetcher.java
+++ b/runtime/executor/src/main/java/edu/snu/nemo/runtime/executor/task/DataFetcher.java
@@ -39,7 +39,7 @@ abstract class DataFetcher {
   }
 
   /**
-   * This call can block.
+   * Can block until the next data element becomes available.
    * @return data element
    * @throws IOException upon I/O error
    * @throws java.util.NoSuchElementException if no more element is available

--- a/runtime/executor/src/main/java/edu/snu/nemo/runtime/executor/task/DataFetcher.java
+++ b/runtime/executor/src/main/java/edu/snu/nemo/runtime/executor/task/DataFetcher.java
@@ -17,6 +17,8 @@ package edu.snu.nemo.runtime.executor.task;
 
 import edu.snu.nemo.common.ir.vertex.IRVertex;
 
+import java.io.IOException;
+
 /**
  * An abstraction for fetching data from task-external sources.
  */
@@ -39,10 +41,10 @@ abstract class DataFetcher {
   /**
    * This call can block.
    * @return data element
+   * @throws IOException upon I/O error
    * @throws java.util.NoSuchElementException if no more element is available
-   * @throws RuntimeException if an I/O error occurs during fetching
    */
-  abstract Object fetchDataElement();
+  abstract Object fetchDataElement() throws IOException;
 
   VertexHarness getChild() {
     return child;

--- a/runtime/executor/src/main/java/edu/snu/nemo/runtime/executor/task/ParentTaskDataFetcher.java
+++ b/runtime/executor/src/main/java/edu/snu/nemo/runtime/executor/task/ParentTaskDataFetcher.java
@@ -66,16 +66,16 @@ class ParentTaskDataFetcher extends DataFetcher {
         hasFetchStarted = true;
       }
 
+      // Return the current iterator's element
       if (this.currentIterator.hasNext()) {
         return this.currentIterator.next();
-      } else {
-        if (currentIteratorIndex == expectedNumOfIterators) {
-          throw new NoSuchElementException();
-        } else {
-          countBytes(currentIterator);
-          advanceIterator();
-          return fetchDataElement(); // recursive call, with the next iterator
-        }
+      }
+
+      // Return the next iterator's element
+      if (currentIteratorIndex < expectedNumOfIterators) {
+        countBytes(currentIterator);
+        advanceIterator();
+        return fetchDataElement(); // recursive call, with the next iterator
       }
     } catch (final Throwable e) {
       // Any failure is caught and thrown as an IOException, so that the task is retried.
@@ -85,6 +85,9 @@ class ParentTaskDataFetcher extends DataFetcher {
       // "throw Exception" that the TaskExecutor thread can catch and handle.
       throw new IOException(e);
     }
+
+    // We've consumed all the data.
+    throw new NoSuchElementException();
   }
 
   private void advanceIterator() throws IOException {

--- a/runtime/executor/src/main/java/edu/snu/nemo/runtime/executor/task/SourceVertexDataFetcher.java
+++ b/runtime/executor/src/main/java/edu/snu/nemo/runtime/executor/task/SourceVertexDataFetcher.java
@@ -20,6 +20,7 @@ import edu.snu.nemo.common.ir.vertex.IRVertex;
 
 import java.io.IOException;
 import java.util.Iterator;
+import java.util.NoSuchElementException;
 
 /**
  * Fetches data from a data source.
@@ -40,24 +41,19 @@ class SourceVertexDataFetcher extends DataFetcher {
   }
 
   @Override
-  boolean hasNext() {
+  Object fetchDataElement() {
     if (iterator == null) {
-      getIteratorLazily();
+      fetchDataLazily();
     }
 
-    return iterator.hasNext();
-  }
-
-  @Override
-  Object next() {
-    if (iterator == null) {
-      getIteratorLazily();
+    if (iterator.hasNext()) {
+      return iterator.next();
+    } else {
+      throw new NoSuchElementException();
     }
-
-    return iterator.next();
   }
 
-  void getIteratorLazily() {
+  private void fetchDataLazily() {
     final long start = System.currentTimeMillis();
     try {
       iterator = this.readable.read().iterator();
@@ -67,7 +63,7 @@ class SourceVertexDataFetcher extends DataFetcher {
     boundedSourceReadTime += System.currentTimeMillis() - start;
   }
 
-  public final long getBoundedSourceReadTime() {
+  final long getBoundedSourceReadTime() {
     return boundedSourceReadTime;
   }
 }

--- a/runtime/executor/src/main/java/edu/snu/nemo/runtime/executor/task/SourceVertexDataFetcher.java
+++ b/runtime/executor/src/main/java/edu/snu/nemo/runtime/executor/task/SourceVertexDataFetcher.java
@@ -41,7 +41,7 @@ class SourceVertexDataFetcher extends DataFetcher {
   }
 
   @Override
-  Object fetchDataElement() {
+  Object fetchDataElement() throws IOException {
     if (iterator == null) {
       fetchDataLazily();
     }
@@ -53,13 +53,9 @@ class SourceVertexDataFetcher extends DataFetcher {
     }
   }
 
-  private void fetchDataLazily() {
+  private void fetchDataLazily() throws IOException {
     final long start = System.currentTimeMillis();
-    try {
-      iterator = this.readable.read().iterator();
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
+    iterator = this.readable.read().iterator();
     boundedSourceReadTime += System.currentTimeMillis() - start;
   }
 

--- a/runtime/executor/src/main/java/edu/snu/nemo/runtime/executor/task/SourceVertexDataFetcher.java
+++ b/runtime/executor/src/main/java/edu/snu/nemo/runtime/executor/task/SourceVertexDataFetcher.java
@@ -40,18 +40,31 @@ class SourceVertexDataFetcher extends DataFetcher {
   }
 
   @Override
-  Object fetchDataElement() throws IOException {
+  boolean hasNext() {
     if (iterator == null) {
-      final long start = System.currentTimeMillis();
-      iterator = this.readable.read().iterator();
-      boundedSourceReadTime += System.currentTimeMillis() - start;
+      getIteratorLazily();
     }
 
-    if (iterator.hasNext()) {
-      return iterator.next();
-    } else {
-      return null;
+    return iterator.hasNext();
+  }
+
+  @Override
+  Object next() {
+    if (iterator == null) {
+      getIteratorLazily();
     }
+
+    return iterator.next();
+  }
+
+  void getIteratorLazily() {
+    final long start = System.currentTimeMillis();
+    try {
+      iterator = this.readable.read().iterator();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+    boundedSourceReadTime += System.currentTimeMillis() - start;
   }
 
   public final long getBoundedSourceReadTime() {

--- a/runtime/executor/src/main/java/edu/snu/nemo/runtime/executor/task/TaskExecutor.java
+++ b/runtime/executor/src/main/java/edu/snu/nemo/runtime/executor/task/TaskExecutor.java
@@ -383,6 +383,15 @@ public final class TaskExecutor {
       for (int i = 0; i < availableFetchers.size(); i++) {
         final DataFetcher dataFetcher = availableFetchers.get(i);
         final Object element;
+
+
+        if (dataFetcher.hasNext()) {
+
+
+        } else {
+
+        }
+
         try {
           element = dataFetcher.fetchDataElement();
         } catch (IOException e) {
@@ -587,7 +596,7 @@ public final class TaskExecutor {
 
     // finalize OutputWriters for additional tagged children
     vertexHarness.getWritersToAdditionalChildrenTasks().values().forEach(outputWriter -> {
-      outputWriter.close();
+
       final Optional<Long> writtenBytes = outputWriter.getWrittenBytes();
       writtenBytes.ifPresent(writtenBytesList::add);
     });

--- a/runtime/executor/src/main/java/edu/snu/nemo/runtime/executor/task/TaskExecutor.java
+++ b/runtime/executor/src/main/java/edu/snu/nemo/runtime/executor/task/TaskExecutor.java
@@ -220,19 +220,15 @@ public final class TaskExecutor {
     }
 
     // Given a single input element, a vertex can produce many output elements.
-    // Here, we recursively process all of the main output elements.
-    while (!outputCollector.isEmpty()) {
-      final Object element = outputCollector.remove();
-      handleMainOutputElement(vertexHarness, element); // Recursion
-    }
+    // Here, we recursively process all of the main oltput elements.
+    outputCollector.iterateMain().forEach(element -> handleMainOutputElement(vertexHarness, element)); // Recursion
+    outputCollector.clearMain();
 
     // Recursively process all of the additional output elements.
-    vertexHarness.getContext().getAdditionalTagOutputs().values().forEach(value -> {
-      final String dstVertexId = (String) value;
-      while (!outputCollector.isEmpty(dstVertexId)) {
-        final Object element = outputCollector.remove(dstVertexId);
-        handleAdditionalOutputElement(vertexHarness, element, dstVertexId); // Recursion
-      }
+    vertexHarness.getContext().getAdditionalTagOutputs().values().forEach(tag -> {
+      outputCollector.iterateTag(tag).forEach(
+          element -> handleAdditionalOutputElement(vertexHarness, element, tag)); // Recursion
+      outputCollector.clearTag(tag);
     });
   }
 
@@ -326,17 +322,14 @@ public final class TaskExecutor {
     final OutputCollectorImpl outputCollector = vertexHarness.getOutputCollector();
 
     // handle main outputs
-    while (!outputCollector.isEmpty()) {
-      final Object element = outputCollector.remove();
-      handleMainOutputElement(vertexHarness, element);
-    }
+    outputCollector.iterateMain().forEach(element -> handleMainOutputElement(vertexHarness, element)); // Recursion
+    outputCollector.clearMain();
 
     // handle additional tagged outputs
     vertexHarness.getAdditionalTagOutputChildren().keySet().forEach(tag -> {
-      while (!outputCollector.isEmpty(tag)) {
-        final Object element = outputCollector.remove(tag);
-        handleAdditionalOutputElement(vertexHarness, element, tag);
-      }
+      outputCollector.iterateTag(tag).forEach(
+          element -> handleAdditionalOutputElement(vertexHarness, element, tag)); // Recursion
+      outputCollector.clearTag(tag);
     });
     finalizeOutputWriters(vertexHarness);
   }

--- a/runtime/executor/src/main/java/edu/snu/nemo/runtime/executor/task/TaskExecutor.java
+++ b/runtime/executor/src/main/java/edu/snu/nemo/runtime/executor/task/TaskExecutor.java
@@ -35,7 +35,6 @@ import edu.snu.nemo.runtime.executor.MetricMessageSender;
 import edu.snu.nemo.runtime.executor.TaskStateManager;
 import edu.snu.nemo.runtime.executor.datatransfer.*;
 
-import java.io.IOException;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -384,17 +383,11 @@ public final class TaskExecutor {
         final DataFetcher dataFetcher = availableFetchers.get(i);
         final Object element;
 
-
-        if (dataFetcher.hasNext()) {
-
-
-        } else {
-
-        }
-
         try {
           element = dataFetcher.fetchDataElement();
-        } catch (IOException e) {
+        } catch (NoSuchElementException e) {
+          // TODO: handle null Do something
+        } catch (Throwable e) {
           taskStateManager.onTaskStateChanged(TaskState.State.SHOULD_RETRY,
               Optional.empty(), Optional.of(TaskState.RecoverableTaskFailureCause.INPUT_READ_FAILURE));
           LOG.error("{} Execution Failed (Recoverable: input read failure)! Exception: {}", taskId, e.toString());

--- a/runtime/executor/src/main/java/edu/snu/nemo/runtime/executor/task/TaskExecutor.java
+++ b/runtime/executor/src/main/java/edu/snu/nemo/runtime/executor/task/TaskExecutor.java
@@ -35,6 +35,7 @@ import edu.snu.nemo.runtime.executor.MetricMessageSender;
 import edu.snu.nemo.runtime.executor.TaskStateManager;
 import edu.snu.nemo.runtime.executor.datatransfer.*;
 
+import java.io.IOException;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -395,9 +396,8 @@ public final class TaskExecutor {
           }
           finishedFetcherIndex = i;
           break;
-        } catch (Throwable e) {
-          // Catch ANY exception occurred during fetching data.
-          // This task should be retried.
+        } catch (IOException e) {
+          // IOException means that this task should be retried.
           taskStateManager.onTaskStateChanged(TaskState.State.SHOULD_RETRY,
               Optional.empty(), Optional.of(TaskState.RecoverableTaskFailureCause.INPUT_READ_FAILURE));
           LOG.error("{} Execution Failed (Recoverable: input read failure)! Exception: {}", taskId, e.toString());

--- a/runtime/executor/src/main/java/edu/snu/nemo/runtime/executor/task/TaskExecutor.java
+++ b/runtime/executor/src/main/java/edu/snu/nemo/runtime/executor/task/TaskExecutor.java
@@ -396,6 +396,7 @@ public final class TaskExecutor {
           finishedFetcherIndex = i;
           break;
         } catch (Throwable e) {
+          // Catch ANY exception occurred during fetching data.
           // This task should be retried.
           taskStateManager.onTaskStateChanged(TaskState.State.SHOULD_RETRY,
               Optional.empty(), Optional.of(TaskState.RecoverableTaskFailureCause.INPUT_READ_FAILURE));

--- a/runtime/executor/src/test/java/edu/snu/nemo/runtime/executor/task/ParentTaskDataFetcherTest.java
+++ b/runtime/executor/src/test/java/edu/snu/nemo/runtime/executor/task/ParentTaskDataFetcherTest.java
@@ -45,31 +45,30 @@ import static org.mockito.Mockito.when;
 @PrepareForTest({InputReader.class, VertexHarness.class})
 public final class ParentTaskDataFetcherTest {
 
-  @Test(timeout=5000)
-  public void testVoid() throws Exception {
-    // TODO #173: Properly handle zero-element. This test should be updated too.
-    final List<String> dataElements = new ArrayList<>(0); // empty data
-    final InputReader inputReader = generateInputReaderWithCoder(generateCompletableFuture(dataElements.iterator()),
-        "VoidCoder");
-
-    // Fetcher
-    final ParentTaskDataFetcher fetcher = createFetcher(inputReader);
-
-    // Should return Void.TYPE
-    assertEquals(Void.TYPE, fetcher.fetchDataElement());
-  }
-
-  @Test(timeout=5000)
+  @Test(timeout=5000, expected = NoSuchElementException.class)
   public void testEmpty() throws Exception {
-    // TODO #173: Properly handle zero-element. This test should be updated too.
-    final List<String> dataElements = new ArrayList<>(0); // empty data
-    final InputReader inputReader = generateInputReaderWithCoder(generateCompletableFuture(dataElements.iterator()),
+    final List<String> empty = new ArrayList<>(0); // empty data
+    final InputReader inputReader = generateInputReaderWithCoder(generateCompletableFuture(empty.iterator()),
         "IntCoder");
 
     // Fetcher
     final ParentTaskDataFetcher fetcher = createFetcher(inputReader);
 
-    // Should return Void.TYPE
+    // Should trigger the expected 'NoSuchElementException'
+    fetcher.fetchDataElement();
+  }
+
+  @Test(timeout=5000)
+  public void testNull() throws Exception {
+    final List<String> oneNull = new ArrayList<>(1); // empty data
+    oneNull.add(null);
+    final InputReader inputReader = generateInputReaderWithCoder(generateCompletableFuture(oneNull.iterator()),
+        "VoidCoder");
+
+    // Fetcher
+    final ParentTaskDataFetcher fetcher = createFetcher(inputReader);
+
+    // Should return 'null'
     assertEquals(null, fetcher.fetchDataElement());
   }
 
@@ -84,9 +83,8 @@ public final class ParentTaskDataFetcherTest {
     // Fetcher
     final ParentTaskDataFetcher fetcher = createFetcher(inputReader);
 
-    // Should return only a single element
+    // Should return the element
     assertEquals(singleData, fetcher.fetchDataElement());
-    assertEquals(null, fetcher.fetchDataElement());
   }
 
   @Test(timeout=5000, expected = IOException.class)

--- a/runtime/executor/src/test/java/edu/snu/nemo/runtime/executor/task/ParentTaskDataFetcherTest.java
+++ b/runtime/executor/src/test/java/edu/snu/nemo/runtime/executor/task/ParentTaskDataFetcherTest.java
@@ -15,11 +15,7 @@
  */
 package edu.snu.nemo.runtime.executor.task;
 
-import edu.snu.nemo.common.coder.DecoderFactory;
-import edu.snu.nemo.common.ir.edge.executionproperty.DecoderProperty;
-import edu.snu.nemo.common.ir.executionproperty.ExecutionPropertyMap;
 import edu.snu.nemo.common.ir.vertex.IRVertex;
-import edu.snu.nemo.runtime.common.plan.RuntimeEdge;
 import edu.snu.nemo.runtime.executor.data.DataUtil;
 import edu.snu.nemo.runtime.executor.datatransfer.InputReader;
 import org.junit.Test;
@@ -35,7 +31,6 @@ import java.util.concurrent.Executors;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockingDetails;
 import static org.mockito.Mockito.when;
 
 /**
@@ -48,8 +43,7 @@ public final class ParentTaskDataFetcherTest {
   @Test(timeout=5000, expected = NoSuchElementException.class)
   public void testEmpty() throws Exception {
     final List<String> empty = new ArrayList<>(0); // empty data
-    final InputReader inputReader = generateInputReaderWithCoder(generateCompletableFuture(empty.iterator()),
-        "IntCoder");
+    final InputReader inputReader = generateInputReader(generateCompletableFuture(empty.iterator()));
 
     // Fetcher
     final ParentTaskDataFetcher fetcher = createFetcher(inputReader);
@@ -62,8 +56,7 @@ public final class ParentTaskDataFetcherTest {
   public void testNull() throws Exception {
     final List<String> oneNull = new ArrayList<>(1); // empty data
     oneNull.add(null);
-    final InputReader inputReader = generateInputReaderWithCoder(generateCompletableFuture(oneNull.iterator()),
-        "VoidCoder");
+    final InputReader inputReader = generateInputReader(generateCompletableFuture(oneNull.iterator()));
 
     // Fetcher
     final ParentTaskDataFetcher fetcher = createFetcher(inputReader);
@@ -127,28 +120,6 @@ public final class ParentTaskDataFetcherTest {
         readerForParentTask, // This is the only argument that affects the behavior of ParentTaskDataFetcher
         mock(VertexHarness.class),
         false);
-  }
-
-
-  private DecoderFactory generateCoder(final String coder) {
-    final DecoderFactory decoderFactory = mock(DecoderFactory.class);
-    when(decoderFactory.toString()).thenReturn(coder);
-    return decoderFactory;
-  }
-
-  private RuntimeEdge generateEdge(final String coder) {
-    final String runtimeIREdgeId = "Runtime edge with coder";
-    final ExecutionPropertyMap edgeProperties = new ExecutionPropertyMap(runtimeIREdgeId);
-    edgeProperties.put(DecoderProperty.of(generateCoder(coder)));
-    return new RuntimeEdge<>(runtimeIREdgeId, edgeProperties, mock(IRVertex.class), mock(IRVertex.class), false);
-  }
-
-  private InputReader generateInputReaderWithCoder(final CompletableFuture completableFuture, final String coder) {
-    final InputReader inputReader = mock(InputReader.class);
-    when(inputReader.read()).thenReturn(Arrays.asList(completableFuture));
-    final RuntimeEdge runtimeEdge = generateEdge(coder);
-    when(inputReader.getRuntimeEdge()).thenReturn(runtimeEdge);
-    return inputReader;
   }
 
   private InputReader generateInputReader(final CompletableFuture completableFuture) {

--- a/runtime/executor/src/test/java/edu/snu/nemo/runtime/executor/task/ParentTaskDataFetcherTest.java
+++ b/runtime/executor/src/test/java/edu/snu/nemo/runtime/executor/task/ParentTaskDataFetcherTest.java
@@ -83,7 +83,7 @@ public final class ParentTaskDataFetcherTest {
     // Fetcher
     final ParentTaskDataFetcher fetcher = createFetcher(inputReader);
 
-    // Should return the element
+    // Should return only a single element
     assertEquals(singleData, fetcher.fetchDataElement());
   }
 


### PR DESCRIPTION
JIRA: [NEMO-160: Handle Beam VoidCoder properly](https://issues.apache.org/jira/projects/NEMO/issues/NEMO-160)

**Major changes:**
- Proper support for (1) empty, or (2) 'null'-value input in DataFetchers
- Allow 'null' values emitted by user code (e.g., Create.of((Void) null) by Beam WriteFiles) to be passed around in the data plane
- Remove specific assumptions about Beam VoidCoder in the data plane (e.g., Void.TYPE), and use the coder transparently just like we use any other coders
- DataFetcher throws a NoSuchElementException instead of returning 'null', when indicating that all data has been fetched

**Minor changes to note:**
- Cleans up tests

**Tests for the changes:**
- ParentTaskDataFetcherTest#testEmpty, testNull

**Other comments:**
- N/A

resolves [NEMO-160](https://issues.apache.org/jira/projects/NEMO/issues/NEMO-160)
