### PR TITLE
[NEMO-152] Support Multiple DAGs Execution in a Single User Program

### DIFF
--- a/bin/json2dot.py
+++ b/bin/json2dot.py
@@ -46,13 +46,13 @@ def stateToColor(state):
 
 class JobState:
     def __init__(self, data):
-        self.id = data['jobId']
+        self.id = data['planId']
         self.stages = {}
         for stage in data['stages']:
             self.stages[stage['id']] = StageState(stage)
     @classmethod
     def empty(cls):
-        return cls({'jobId': None, 'stages': []})
+        return cls({'planId': None, 'stages': []})
     def get(self, id):
         try:
             return self.stages[id]

--- a/bin/json2dot.py
+++ b/bin/json2dot.py
@@ -44,7 +44,7 @@ def stateToColor(state):
     except:
         return 'white'
 
-class JobState:
+class PlanState:
     def __init__(self, data):
         self.id = data['planId']
         self.stages = {}
@@ -96,11 +96,11 @@ class DAG:
     A class for converting DAG to Graphviz representation.
     JSON representation should be formatted like what toString method in DAG.java does.
     '''
-    def __init__(self, dag, jobState):
+    def __init__(self, dag, planState):
         self.vertices = {}
         self.edges = []
         for vertex in dag['vertices']:
-            self.vertices[vertex['id']] = Vertex(vertex['id'], vertex['properties'], jobState.get(vertex['id']))
+            self.vertices[vertex['id']] = Vertex(vertex['id'], vertex['properties'], planState.get(vertex['id']))
         for edge in dag['edges']:
             self.edges.append(Edge(self.vertices[edge['src']], self.vertices[edge['dst']], edge['properties']))
     @property
@@ -178,7 +178,7 @@ class NormalVertex:
 class LoopVertex:
     def __init__(self, id, properties):
         self.id = id
-        self.dag = DAG(properties['DAG'], JobState.empty())
+        self.dag = DAG(properties['DAG'], PlanState.empty())
         self.remaining_iteration = properties['remainingIteration']
         self.executionProperties = properties['executionProperties']
         self.incoming = properties['dagIncomingEdges']
@@ -217,7 +217,7 @@ class Stage:
     def __init__(self, id, properties, state):
         self.id = id
         self.properties = properties
-        self.stageDAG = DAG(properties['irDag'], JobState.empty())
+        self.stageDAG = DAG(properties['irDag'], PlanState.empty())
         self.idx = getIdx()
         self.state = state
         self.executionProperties = self.properties['executionProperties']
@@ -316,9 +316,9 @@ class RuntimeEdge:
 
 def jsonToDot(jsonDict):
     try:
-        dag = DAG(jsonDict['dag'], JobState(jsonDict['jobState']))
+        dag = DAG(jsonDict['dag'], PlanState(jsonDict['planState']))
     except:
-        dag = DAG(jsonDict, JobState.empty())
+        dag = DAG(jsonDict, PlanState.empty())
     return 'digraph dag {compound=true; nodesep=1.0; forcelabels=true;' + dag.dot + '}'
 
 if __name__ == "__main__":

--- a/client/src/main/java/edu/snu/nemo/client/ClientEndpoint.java
+++ b/client/src/main/java/edu/snu/nemo/client/ClientEndpoint.java
@@ -24,12 +24,12 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 /**
- * A request endpoint in client side of a job.
+ * A request endpoint in client side of a plan.
  */
 public abstract class ClientEndpoint {
 
   /**
-   * The request endpoint in driver side of the job.
+   * The request endpoint in driver side of the plan.
    */
   private final AtomicReference<DriverEndpoint> driverEndpoint;
 
@@ -41,13 +41,13 @@ public abstract class ClientEndpoint {
   private static final long DEFAULT_DRIVER_WAIT_IN_MILLIS = 100;
 
   /**
-   * A {@link StateTranslator} for this job.
+   * A {@link StateTranslator} for this plan.
    */
   private final StateTranslator stateTranslator;
 
   /**
    * Constructor.
-   * @param stateTranslator translator to translate between the state of job and corresponding.
+   * @param stateTranslator translator to translate between the state of plan and corresponding.
    */
   public ClientEndpoint(final StateTranslator stateTranslator) {
     this.driverEndpoint = new AtomicReference<>();
@@ -57,7 +57,7 @@ public abstract class ClientEndpoint {
   }
 
   /**
-   * Connect the driver endpoint of this job.
+   * Connect the driver endpoint of this plan.
    * This method will be called by {@link DriverEndpoint}.
    *
    * @param dep connected with this client.
@@ -122,11 +122,11 @@ public abstract class ClientEndpoint {
   }
 
   /**
-   * Get the current state of the running job.
+   * Get the current state of the running plan.
    *
-   * @return the current state of the running job.
+   * @return the current state of the running plan.
    */
-  public final synchronized Enum getJobState() {
+  public final synchronized Enum getPlanState() {
     if (driverEndpoint.get() != null) {
       return stateTranslator.translateState(driverEndpoint.get().getState());
     } else {

--- a/client/src/main/java/edu/snu/nemo/client/ClientEndpoint.java
+++ b/client/src/main/java/edu/snu/nemo/client/ClientEndpoint.java
@@ -15,7 +15,7 @@
  */
 package edu.snu.nemo.client;
 
-import edu.snu.nemo.runtime.common.state.JobState;
+import edu.snu.nemo.runtime.common.state.PlanState;
 
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -130,7 +130,7 @@ public abstract class ClientEndpoint {
     if (driverEndpoint.get() != null) {
       return stateTranslator.translateState(driverEndpoint.get().getState());
     } else {
-      return stateTranslator.translateState(JobState.State.READY);
+      return stateTranslator.translateState(PlanState.State.READY);
     }
   }
 
@@ -161,7 +161,7 @@ public abstract class ClientEndpoint {
         return stateTranslator.translateState(driverEndpoint.get().
             waitUntilFinish(timeout - unit.convert(consumedTime, TimeUnit.NANOSECONDS), unit));
       } else {
-        return JobState.State.READY;
+        return PlanState.State.READY;
       }
     }
   }
@@ -181,7 +181,7 @@ public abstract class ClientEndpoint {
       if (driverIsConnected) {
         return stateTranslator.translateState(driverEndpoint.get().waitUntilFinish());
       } else {
-        return JobState.State.READY;
+        return PlanState.State.READY;
       }
     }
   }

--- a/client/src/main/java/edu/snu/nemo/client/DriverEndpoint.java
+++ b/client/src/main/java/edu/snu/nemo/client/DriverEndpoint.java
@@ -15,8 +15,8 @@
  */
 package edu.snu.nemo.client;
 
-import edu.snu.nemo.runtime.common.state.JobState;
-import edu.snu.nemo.runtime.master.JobStateManager;
+import edu.snu.nemo.runtime.common.state.PlanState;
+import edu.snu.nemo.runtime.master.PlanStateManager;
 
 import java.util.concurrent.TimeUnit;
 
@@ -26,9 +26,9 @@ import java.util.concurrent.TimeUnit;
 public final class DriverEndpoint {
 
   /**
-   * The {@link JobStateManager} of the running job.
+   * The {@link PlanStateManager} of the running job.
    */
-  private final JobStateManager jobStateManager;
+  private final PlanStateManager planStateManager;
 
   /**
    * The {@link ClientEndpoint} of the job.
@@ -38,12 +38,12 @@ public final class DriverEndpoint {
   /**
    * Construct an endpoint in driver side.
    * This method will be called by {@link ClientEndpoint}.
-   * @param jobStateManager of running job.
+   * @param planStateManager of running job.
    * @param clientEndpoint of running job.
    */
-  public DriverEndpoint(final JobStateManager jobStateManager,
+  public DriverEndpoint(final PlanStateManager planStateManager,
                         final ClientEndpoint clientEndpoint) {
-    this.jobStateManager = jobStateManager;
+    this.planStateManager = planStateManager;
     this.clientEndpoint = clientEndpoint;
     clientEndpoint.connectDriver(this);
   }
@@ -53,8 +53,8 @@ public final class DriverEndpoint {
    * This method will be called by {@link ClientEndpoint}.
    * @return the current state of the running job.
    */
-  JobState.State getState() {
-    return jobStateManager.getJobState();
+  PlanState.State getState() {
+    return planStateManager.getPlanState();
   }
 
   /**
@@ -65,9 +65,9 @@ public final class DriverEndpoint {
    * @param unit of the timeout.
    * @return the final state of this job.
    */
-  JobState.State waitUntilFinish(final long timeout,
-                                 final TimeUnit unit) {
-    return jobStateManager.waitUntilFinish(timeout, unit);
+  PlanState.State waitUntilFinish(final long timeout,
+                                  final TimeUnit unit) {
+    return planStateManager.waitUntilFinish(timeout, unit);
   }
 
   /**
@@ -75,7 +75,7 @@ public final class DriverEndpoint {
    * This method will be called by {@link ClientEndpoint}.
    * @return the final state of this job.
    */
-  JobState.State waitUntilFinish() {
-    return jobStateManager.waitUntilFinish();
+  PlanState.State waitUntilFinish() {
+    return planStateManager.waitUntilFinish();
   }
 }

--- a/client/src/main/java/edu/snu/nemo/client/DriverEndpoint.java
+++ b/client/src/main/java/edu/snu/nemo/client/DriverEndpoint.java
@@ -21,25 +21,25 @@ import edu.snu.nemo.runtime.master.PlanStateManager;
 import java.util.concurrent.TimeUnit;
 
 /**
- * A request endpoint in driver side of a job.
+ * A request endpoint in driver side of a plan.
  */
 public final class DriverEndpoint {
 
   /**
-   * The {@link PlanStateManager} of the running job.
+   * The {@link PlanStateManager} of the running plan.
    */
   private final PlanStateManager planStateManager;
 
   /**
-   * The {@link ClientEndpoint} of the job.
+   * The {@link ClientEndpoint} of the plan.
    */
   private final ClientEndpoint clientEndpoint;
 
   /**
    * Construct an endpoint in driver side.
    * This method will be called by {@link ClientEndpoint}.
-   * @param planStateManager of running job.
-   * @param clientEndpoint of running job.
+   * @param planStateManager of running plan.
+   * @param clientEndpoint of running plan.
    */
   public DriverEndpoint(final PlanStateManager planStateManager,
                         final ClientEndpoint clientEndpoint) {
@@ -49,21 +49,21 @@ public final class DriverEndpoint {
   }
 
   /**
-   * Get the current state of the running job.
+   * Get the current state of the running plan.
    * This method will be called by {@link ClientEndpoint}.
-   * @return the current state of the running job.
+   * @return the current state of the running plan.
    */
   PlanState.State getState() {
     return planStateManager.getPlanState();
   }
 
   /**
-   * Wait for this job to be finished and return the final state.
+   * Wait for this plan to be finished and return the final state.
    * It wait for at most the given time.
    * This method will be called by {@link ClientEndpoint}.
    * @param timeout of waiting.
    * @param unit of the timeout.
-   * @return the final state of this job.
+   * @return the final state of this plan.
    */
   PlanState.State waitUntilFinish(final long timeout,
                                   final TimeUnit unit) {
@@ -71,9 +71,9 @@ public final class DriverEndpoint {
   }
 
   /**
-   * Wait for this job to be finished and return the final state.
+   * Wait for this plan to be finished and return the final state.
    * This method will be called by {@link ClientEndpoint}.
-   * @return the final state of this job.
+   * @return the final state of this plan.
    */
   PlanState.State waitUntilFinish() {
     return planStateManager.waitUntilFinish();

--- a/client/src/main/java/edu/snu/nemo/client/StateTranslator.java
+++ b/client/src/main/java/edu/snu/nemo/client/StateTranslator.java
@@ -18,16 +18,15 @@ package edu.snu.nemo.client;
 import edu.snu.nemo.runtime.common.state.PlanState;
 
 /**
- * A class provides the translation between the state of job and corresponding
- * {@link ClientEndpoint}.
+ * A class provides the translation between the state of plan and corresponding {@link ClientEndpoint}.
  */
 public interface StateTranslator {
 
   /**
-   * Translate a job state of nemo to a corresponding client endpoint state.
+   * Translate a plan state of nemo to a corresponding client endpoint state.
    *
-   * @param jobState to translate.
+   * @param planState to translate.
    * @return the translated state.
    */
-  Enum translateState(final PlanState.State jobState);
+  Enum translateState(final PlanState.State planState);
 }

--- a/client/src/main/java/edu/snu/nemo/client/StateTranslator.java
+++ b/client/src/main/java/edu/snu/nemo/client/StateTranslator.java
@@ -15,7 +15,7 @@
  */
 package edu.snu.nemo.client;
 
-import edu.snu.nemo.runtime.common.state.JobState;
+import edu.snu.nemo.runtime.common.state.PlanState;
 
 /**
  * A class provides the translation between the state of job and corresponding
@@ -29,5 +29,5 @@ public interface StateTranslator {
    * @param jobState to translate.
    * @return the translated state.
    */
-  Enum translateState(final JobState.State jobState);
+  Enum translateState(final PlanState.State jobState);
 }

--- a/client/src/test/java/edu/snu/nemo/client/ClientEndpointTest.java
+++ b/client/src/test/java/edu/snu/nemo/client/ClientEndpointTest.java
@@ -50,7 +50,7 @@ public class ClientEndpointTest {
     final StateTranslator stateTranslator = mock(StateTranslator.class);
     when(stateTranslator.translateState(any())).then(state -> state.getArgument(0));
     final ClientEndpoint clientEndpoint = new TestClientEndpoint(stateTranslator);
-    assertEquals(clientEndpoint.getJobState(), PlanState.State.READY);
+    assertEquals(clientEndpoint.getPlanState(), PlanState.State.READY);
 
     // Wait for connection but not connected.
     assertEquals(clientEndpoint.waitUntilJobFinish(100, TimeUnit.MILLISECONDS), PlanState.State.READY);
@@ -64,7 +64,7 @@ public class ClientEndpointTest {
     final DriverEndpoint driverEndpoint = new DriverEndpoint(planStateManager, clientEndpoint);
 
     // Check the current state.
-    assertEquals(clientEndpoint.getJobState(), PlanState.State.EXECUTING);
+    assertEquals(clientEndpoint.getPlanState(), PlanState.State.EXECUTING);
 
     // Wait for the job to finish but not finished
     assertEquals(clientEndpoint.waitUntilJobFinish(100, TimeUnit.MILLISECONDS), PlanState.State.EXECUTING);

--- a/common/src/main/java/edu/snu/nemo/common/dag/DAG.java
+++ b/common/src/main/java/edu/snu/nemo/common/dag/DAG.java
@@ -84,17 +84,6 @@ public final class DAG<V extends Vertex, E extends Edge<V>> implements Serializa
   }
 
   /**
-   * Converts a DAG into another DAG according to a function.
-   * @param function to apply when converting a DAG to another.
-   * @param <V2> the converted DAG's vertex type.
-   * @param <E2> the converted DAG's edge type.
-   * @return the converted DAG.
-   */
-  public <V2 extends Vertex, E2 extends Edge<V2>> DAG<V2, E2> convert(final Function<DAG<V, E>, DAG<V2, E2>> function) {
-    return function.apply(this);
-  }
-
-  /**
    * Retrieves the vertex given its ID.
    * @param id of the vertex to retrieve
    * @return the vertex

--- a/common/src/main/java/edu/snu/nemo/common/dag/DAG.java
+++ b/common/src/main/java/edu/snu/nemo/common/dag/DAG.java
@@ -27,7 +27,6 @@ import java.io.PrintWriter;
 import java.io.Serializable;
 import java.util.*;
 import java.util.function.Consumer;
-import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 

--- a/compiler/backend/src/main/java/edu/snu/nemo/compiler/backend/nemo/NemoBackend.java
+++ b/compiler/backend/src/main/java/edu/snu/nemo/compiler/backend/nemo/NemoBackend.java
@@ -60,8 +60,7 @@ public final class NemoBackend implements Backend<PhysicalPlan> {
    */
   public PhysicalPlan compile(final DAG<IRVertex, IREdge> irDAG,
                               final PhysicalPlanGenerator physicalPlanGenerator) {
-    final DAG<Stage, StageEdge> stageDAG = irDAG.convert(physicalPlanGenerator);
-    final PhysicalPlan physicalPlan = new PhysicalPlan(RuntimeIdGenerator.generatePhysicalPlanId(), stageDAG);
-    return physicalPlan;
+    final DAG<Stage, StageEdge> stageDAG = physicalPlanGenerator.apply(irDAG);
+    return new PhysicalPlan(RuntimeIdGenerator.generatePhysicalPlanId(), stageDAG);
   }
 }

--- a/compiler/frontend/beam/src/main/java/edu/snu/nemo/compiler/frontend/beam/BeamStateTranslator.java
+++ b/compiler/frontend/beam/src/main/java/edu/snu/nemo/compiler/frontend/beam/BeamStateTranslator.java
@@ -16,7 +16,7 @@
 package edu.snu.nemo.compiler.frontend.beam;
 
 import edu.snu.nemo.client.StateTranslator;
-import edu.snu.nemo.runtime.common.state.JobState;
+import edu.snu.nemo.runtime.common.state.PlanState;
 
 import static org.apache.beam.sdk.PipelineResult.State.*;
 
@@ -33,7 +33,7 @@ public final class BeamStateTranslator implements StateTranslator {
    * @return the translated state.
    */
   @Override
-  public Enum translateState(final JobState.State jobState) {
+  public Enum translateState(final PlanState.State jobState) {
     switch (jobState) {
       case READY:
         return RUNNING;

--- a/compiler/frontend/beam/src/main/java/edu/snu/nemo/compiler/frontend/beam/NemoPipelineResult.java
+++ b/compiler/frontend/beam/src/main/java/edu/snu/nemo/compiler/frontend/beam/NemoPipelineResult.java
@@ -37,7 +37,7 @@ public final class NemoPipelineResult extends ClientEndpoint implements Pipeline
 
   @Override
   public State getState() {
-    return (State) super.getJobState();
+    return (State) super.getPlanState();
   }
 
   @Override

--- a/compiler/frontend/spark/src/main/java/edu/snu/nemo/compiler/frontend/spark/sql/SparkSession.java
+++ b/compiler/frontend/spark/src/main/java/edu/snu/nemo/compiler/frontend/spark/sql/SparkSession.java
@@ -321,6 +321,9 @@ public final class SparkSession extends org.apache.spark.sql.SparkSession implem
       if (!options.containsKey("spark.master")) { // default spark_master option.
         return this.master("local[*]").getOrCreate();
       }
+      if (!options.containsKey("spark.driver.allowMultipleContexts")) {
+        return this.config("spark.driver.allowMultipleContexts", "true").getOrCreate();
+      }
 
       UserGroupInformation.setLoginUser(UserGroupInformation.createRemoteUser("ubuntu"));
 

--- a/compiler/optimizer/src/main/java/edu/snu/nemo/compiler/optimizer/policy/Policy.java
+++ b/compiler/optimizer/src/main/java/edu/snu/nemo/compiler/optimizer/policy/Policy.java
@@ -20,15 +20,14 @@ import edu.snu.nemo.common.eventhandler.PubSubEventHandlerWrapper;
 import edu.snu.nemo.common.ir.edge.IREdge;
 import edu.snu.nemo.common.ir.vertex.IRVertex;
 import org.apache.reef.tang.Injector;
-import org.apache.reef.tang.annotations.DefaultImplementation;
 
 import java.io.Serializable;
 
 /**
  * An interface for policies, each of which is composed of a list of static optimization passes.
  * The list of static optimization passes are run in the order provided by the implementation.
+ * Most policies follow the implementation in {@link PolicyImpl}.
  */
-@DefaultImplementation(PolicyImpl.class)
 public interface Policy extends Serializable {
   /**
    * Optimize the DAG with the compile time optimizations.

--- a/compiler/optimizer/src/main/java/edu/snu/nemo/compiler/optimizer/policy/Policy.java
+++ b/compiler/optimizer/src/main/java/edu/snu/nemo/compiler/optimizer/policy/Policy.java
@@ -20,6 +20,7 @@ import edu.snu.nemo.common.eventhandler.PubSubEventHandlerWrapper;
 import edu.snu.nemo.common.ir.edge.IREdge;
 import edu.snu.nemo.common.ir.vertex.IRVertex;
 import org.apache.reef.tang.Injector;
+import org.apache.reef.tang.annotations.DefaultImplementation;
 
 import java.io.Serializable;
 
@@ -27,6 +28,7 @@ import java.io.Serializable;
  * An interface for policies, each of which is composed of a list of static optimization passes.
  * The list of static optimization passes are run in the order provided by the implementation.
  */
+@DefaultImplementation(PolicyImpl.class)
 public interface Policy extends Serializable {
   /**
    * Optimize the DAG with the compile time optimizations.

--- a/compiler/test/src/test/java/edu/snu/nemo/compiler/backend/nemo/DAGConverterTest.java
+++ b/compiler/test/src/test/java/edu/snu/nemo/compiler/backend/nemo/DAGConverterTest.java
@@ -76,7 +76,7 @@ public final class DAGConverterTest {
     final DAG<IRVertex, IREdge> irDAG = new TestPolicy().runCompileTimeOptimization(
         irDAGBuilder.buildWithoutSourceSinkCheck(), DAG.EMPTY_DAG_DIRECTORY);
     final DAG<Stage, StageEdge> DAGOfStages = physicalPlanGenerator.stagePartitionIrDAG(irDAG);
-    final DAG<Stage, StageEdge> physicalDAG = irDAG.convert(physicalPlanGenerator);
+    final DAG<Stage, StageEdge> physicalDAG = physicalPlanGenerator.apply(irDAG);
 
     // Test DAG of stages
     final List<Stage> sortedDAGOfStages = DAGOfStages.getTopologicalSort();

--- a/examples/spark/src/test/java/edu/snu/nemo/examples/spark/MRJava.java
+++ b/examples/spark/src/test/java/edu/snu/nemo/examples/spark/MRJava.java
@@ -67,5 +67,25 @@ public final class MRJava {
     }
   }
 
-  // TODO #152: enable execution of multiple jobs (call scheduleJob multiple times with caching).
+  @Test(timeout = TIMEOUT)
+  public void testSparkWordAndLineCount() throws Exception {
+    final String inputFileName = "test_input_wordcount_spark";
+    final String outputFileName = "test_output_wordcount_spark";
+    final String expectedOutputFilename = "expected_output_wordcount_spark";
+    final String inputFilePath = fileBasePath + inputFileName;
+    final String outputFilePath = fileBasePath + outputFileName;
+
+    JobLauncher.main(builder
+        .addJobId(JavaWordAndLineCount.class.getSimpleName() + "_test")
+        .addUserMain(JavaWordAndLineCount.class.getCanonicalName())
+        .addUserArgs(inputFilePath, outputFilePath)
+        .addOptimizationPolicy(DefaultPolicy.class.getCanonicalName())
+        .build());
+
+    try {
+      ExampleTestUtil.ensureOutputValidity(fileBasePath, outputFileName, expectedOutputFilename);
+    } finally {
+      ExampleTestUtil.deleteOutputFile(fileBasePath, outputFileName);
+    }
+  }
 }

--- a/examples/spark/src/test/java/edu/snu/nemo/examples/spark/MRJava.java
+++ b/examples/spark/src/test/java/edu/snu/nemo/examples/spark/MRJava.java
@@ -71,7 +71,7 @@ public final class MRJava {
   public void testSparkWordAndLineCount() throws Exception {
     final String inputFileName = "test_input_wordcount_spark";
     final String outputFileName = "test_output_wordcount_spark";
-    final String expectedOutputFilename = "expected_output_wordcount_spark";
+    final String expectedOutputFilename = "expected_output_word_and_line_count";
     final String inputFilePath = fileBasePath + inputFileName;
     final String outputFilePath = fileBasePath + outputFileName;
 

--- a/runtime/common/src/main/java/edu/snu/nemo/runtime/common/metric/JobMetric.java
+++ b/runtime/common/src/main/java/edu/snu/nemo/runtime/common/metric/JobMetric.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.snu.nemo.common.dag.DAG;
 import edu.snu.nemo.runtime.common.plan.PhysicalPlan;
-import edu.snu.nemo.runtime.common.state.JobState;
+import edu.snu.nemo.runtime.common.state.PlanState;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -29,9 +29,9 @@ import java.util.List;
 /**
  * Metric class for Job (or {@link PhysicalPlan}).
  */
-public final class JobMetric implements StateMetric<JobState.State> {
+public final class JobMetric implements StateMetric<PlanState.State> {
   private String id;
-  private List<StateTransitionEvent<JobState.State>> stateTransitionEvents = new ArrayList<>();
+  private List<StateTransitionEvent<PlanState.State>> stateTransitionEvents = new ArrayList<>();
   private JsonNode stageDagJson;
 
   public JobMetric(final PhysicalPlan physicalPlan) {
@@ -63,12 +63,12 @@ public final class JobMetric implements StateMetric<JobState.State> {
   }
 
   @Override
-  public List<StateTransitionEvent<JobState.State>> getStateTransitionEvents() {
+  public List<StateTransitionEvent<PlanState.State>> getStateTransitionEvents() {
     return stateTransitionEvents;
   }
 
   @Override
-  public void addEvent(final JobState.State prevState, final JobState.State newState) {
+  public void addEvent(final PlanState.State prevState, final PlanState.State newState) {
     stateTransitionEvents.add(new StateTransitionEvent<>(System.currentTimeMillis(), prevState, newState));
   }
 

--- a/runtime/common/src/main/java/edu/snu/nemo/runtime/common/plan/Task.java
+++ b/runtime/common/src/main/java/edu/snu/nemo/runtime/common/plan/Task.java
@@ -28,7 +28,7 @@ import java.util.Optional;
  * A Task is a self-contained executable that can be executed on a machine.
  */
 public final class Task implements Serializable {
-  private final String jobId;
+  private final String planId;
   private final String taskId;
   private final List<StageEdge> taskIncomingEdges;
   private final List<StageEdge> taskOutgoingEdges;
@@ -40,7 +40,7 @@ public final class Task implements Serializable {
   /**
    * Constructor.
    *
-   * @param jobId                the id of the job.
+   * @param planId               the id of the physical plan.
    * @param taskId               the ID of the task.
    * @param attemptIdx           the attempt index.
    * @param executionProperties  {@link VertexExecutionProperty} map for the corresponding stage
@@ -49,7 +49,7 @@ public final class Task implements Serializable {
    * @param taskOutgoingEdges    the outgoing edges of the task.
    * @param irVertexIdToReadable the map between IRVertex id to readable.
    */
-  public Task(final String jobId,
+  public Task(final String planId,
               final String taskId,
               final int attemptIdx,
               final ExecutionPropertyMap<VertexExecutionProperty> executionProperties,
@@ -57,7 +57,7 @@ public final class Task implements Serializable {
               final List<StageEdge> taskIncomingEdges,
               final List<StageEdge> taskOutgoingEdges,
               final Map<String, Readable> irVertexIdToReadable) {
-    this.jobId = jobId;
+    this.planId = planId;
     this.taskId = taskId;
     this.attemptIdx = attemptIdx;
     this.executionProperties = executionProperties;
@@ -68,10 +68,10 @@ public final class Task implements Serializable {
   }
 
   /**
-   * @return the id of the job.
+   * @return the id of the plan.
    */
-  public String getJobId() {
-    return jobId;
+  public String getPlanId() {
+    return planId;
   }
 
   /**
@@ -138,8 +138,8 @@ public final class Task implements Serializable {
   @Override
   public String toString() {
     final StringBuilder sb = new StringBuilder();
-    sb.append("jobId: ");
-    sb.append(jobId);
+    sb.append("planId: ");
+    sb.append(planId);
     sb.append(" / taskId: ");
     sb.append(taskId);
     sb.append(" / attempt: ");

--- a/runtime/common/src/main/java/edu/snu/nemo/runtime/common/state/PlanState.java
+++ b/runtime/common/src/main/java/edu/snu/nemo/runtime/common/state/PlanState.java
@@ -31,16 +31,16 @@ public final class PlanState {
     final StateMachine.Builder stateMachineBuilder = StateMachine.newBuilder();
 
     // Add states
-    stateMachineBuilder.addState(State.READY, "The job has been created and submitted to runtime.");
-    stateMachineBuilder.addState(State.EXECUTING, "The job is executing (with its stages executing).");
-    stateMachineBuilder.addState(State.COMPLETE, "The job is complete.");
-    stateMachineBuilder.addState(State.FAILED, "Job failed.");
+    stateMachineBuilder.addState(State.READY, "The plan has been created and submitted to runtime.");
+    stateMachineBuilder.addState(State.EXECUTING, "The plan is executing (with its stages executing).");
+    stateMachineBuilder.addState(State.COMPLETE, "The plan is complete.");
+    stateMachineBuilder.addState(State.FAILED, "Plan failed.");
 
     // Add transitions
     stateMachineBuilder.addTransition(State.READY, State.EXECUTING,
         "Begin executing!");
     stateMachineBuilder.addTransition(State.EXECUTING, State.COMPLETE,
-        "All stages complete, job complete");
+        "All stages complete, plan complete");
     stateMachineBuilder.addTransition(State.EXECUTING, State.FAILED,
         "Unrecoverable failure in a stage");
 

--- a/runtime/common/src/main/java/edu/snu/nemo/runtime/common/state/PlanState.java
+++ b/runtime/common/src/main/java/edu/snu/nemo/runtime/common/state/PlanState.java
@@ -20,10 +20,10 @@ import edu.snu.nemo.common.StateMachine;
 /**
  * Represents the states and their transitions of a physical plan.
  */
-public final class JobState {
+public final class PlanState {
   private final StateMachine stateMachine;
 
-  public JobState() {
+  public PlanState() {
     stateMachine = buildTaskStateMachine();
   }
 
@@ -54,7 +54,7 @@ public final class JobState {
   }
 
   /**
-   * JobState.
+   * PlanState.
    */
   public enum State {
     READY,

--- a/runtime/driver/src/main/java/edu/snu/nemo/driver/UserApplicationRunner.java
+++ b/runtime/driver/src/main/java/edu/snu/nemo/driver/UserApplicationRunner.java
@@ -26,7 +26,7 @@ import edu.snu.nemo.compiler.backend.nemo.NemoBackend;
 import edu.snu.nemo.compiler.optimizer.policy.Policy;
 import edu.snu.nemo.conf.JobConf;
 import edu.snu.nemo.runtime.common.plan.PhysicalPlan;
-import edu.snu.nemo.runtime.master.JobStateManager;
+import edu.snu.nemo.runtime.master.PlanStateManager;
 import edu.snu.nemo.runtime.master.RuntimeMaster;
 import org.apache.commons.lang3.SerializationUtils;
 import org.apache.reef.tang.Injector;
@@ -102,16 +102,16 @@ public final class UserApplicationRunner {
       physicalPlan.getStageDAG().storeJSON(dagDirectory, "plan", "physical execution plan by compiler");
 
       // Execute!
-      final Pair<JobStateManager, ScheduledExecutorService> executionResult =
+      final Pair<PlanStateManager, ScheduledExecutorService> executionResult =
           runtimeMaster.execute(physicalPlan, maxScheduleAttempt);
 
       // Wait for the job to finish and stop logging
-      final JobStateManager jobStateManager = executionResult.left();
+      final PlanStateManager planStateManager = executionResult.left();
       final ScheduledExecutorService dagLoggingExecutor = executionResult.right();
-      jobStateManager.waitUntilFinish();
+      planStateManager.waitUntilFinish();
       dagLoggingExecutor.shutdown();
 
-      jobStateManager.storeJSON(dagDirectory, "final");
+      planStateManager.storeJSON(dagDirectory, "final");
       LOG.info("{} is complete!", physicalPlan.getId());
     } catch (final Exception e) {
       throw new RuntimeException(e);

--- a/runtime/master/src/main/java/edu/snu/nemo/runtime/master/BlockManagerMaster.java
+++ b/runtime/master/src/main/java/edu/snu/nemo/runtime/master/BlockManagerMaster.java
@@ -50,6 +50,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static edu.snu.nemo.runtime.common.state.BlockState.State.IN_PROGRESS;
+import static edu.snu.nemo.runtime.common.state.BlockState.State.NOT_AVAILABLE;
 
 /**
  * Master-side block manager.
@@ -229,8 +230,8 @@ public final class BlockManagerMaster {
     try {
       if (producerTaskIdToBlockIds.containsKey(scheduledTaskId)) {
         producerTaskIdToBlockIds.get(scheduledTaskId).forEach(blockId -> {
-          if (!blockIdToMetadata.get(blockId).getBlockState()
-              .getStateMachine().getCurrentState().equals(IN_PROGRESS)) {
+          if (blockIdToMetadata.get(blockId).getBlockState()
+              .getStateMachine().getCurrentState().equals(NOT_AVAILABLE)) {
             onBlockStateChanged(blockId, IN_PROGRESS, null);
           }
         });

--- a/runtime/master/src/main/java/edu/snu/nemo/runtime/master/PlanStateManager.java
+++ b/runtime/master/src/main/java/edu/snu/nemo/runtime/master/PlanStateManager.java
@@ -39,7 +39,6 @@ import edu.snu.nemo.runtime.common.state.TaskState;
 import edu.snu.nemo.runtime.common.metric.JobMetric;
 import edu.snu.nemo.runtime.common.metric.StageMetric;
 import edu.snu.nemo.runtime.common.metric.TaskMetric;
-import edu.snu.nemo.runtime.master.scheduler.BatchScheduler;
 import org.apache.reef.annotations.audience.DriverSide;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -133,9 +132,9 @@ public final class PlanStateManager {
    * Updates the state of a task.
    * Task state changes can occur both in master and executor.
    * State changes that occur in master are
-   * initiated in {@link BatchScheduler}.
+   * initiated in {@link edu.snu.nemo.runtime.master.scheduler.BatchScheduler}.
    * State changes that occur in executors are sent to master as a control message,
-   * and the call to this method is initiated in {@link BatchScheduler}
+   * and the call to this method is initiated in {@link edu.snu.nemo.runtime.master.scheduler.BatchScheduler}
    * when the message/event is received.
    *
    * @param taskId  the ID of the task.

--- a/runtime/master/src/main/java/edu/snu/nemo/runtime/master/RuntimeMaster.java
+++ b/runtime/master/src/main/java/edu/snu/nemo/runtime/master/RuntimeMaster.java
@@ -156,16 +156,16 @@ public final class RuntimeMaster {
    * @param plan to execute
    * @param maxScheduleAttempt the max number of times this plan/sub-part of the plan should be attempted.
    */
-  public Pair<JobStateManager, ScheduledExecutorService> execute(final PhysicalPlan plan,
-                                                                 final int maxScheduleAttempt) {
-    final Callable<Pair<JobStateManager, ScheduledExecutorService>> jobExecutionCallable = () -> {
+  public Pair<PlanStateManager, ScheduledExecutorService> execute(final PhysicalPlan plan,
+                                                                  final int maxScheduleAttempt) {
+    final Callable<Pair<PlanStateManager, ScheduledExecutorService>> jobExecutionCallable = () -> {
       this.irVertices.addAll(plan.getIdToIRVertex().values());
       try {
         blockManagerMaster.initialize(plan);
-        final JobStateManager jobStateManager = new JobStateManager(plan, metricMessageHandler, maxScheduleAttempt);
-        scheduler.scheduleJob(plan, jobStateManager);
-        final ScheduledExecutorService dagLoggingExecutor = scheduleDagLogging(jobStateManager);
-        return Pair.of(jobStateManager, dagLoggingExecutor);
+        final PlanStateManager planStateManager = new PlanStateManager(plan, metricMessageHandler, maxScheduleAttempt);
+        scheduler.scheduleJob(plan, planStateManager);
+        final ScheduledExecutorService dagLoggingExecutor = scheduleDagLogging(planStateManager);
+        return Pair.of(planStateManager, dagLoggingExecutor);
       } catch (Exception e) {
         throw new RuntimeException(e);
       }
@@ -444,17 +444,17 @@ public final class RuntimeMaster {
 
   /**
    * Schedules a periodic DAG logging thread.
-   * @param jobStateManager for the job the DAG should be logged.
+   * @param planStateManager for the job the DAG should be logged.
    * TODO #20: RESTful APIs to Access Job State and Metric.
    * @return the scheduled executor service.
    */
-  private ScheduledExecutorService scheduleDagLogging(final JobStateManager jobStateManager) {
+  private ScheduledExecutorService scheduleDagLogging(final PlanStateManager planStateManager) {
     final ScheduledExecutorService dagLoggingExecutor = Executors.newSingleThreadScheduledExecutor();
     dagLoggingExecutor.scheduleAtFixedRate(new Runnable() {
       private int dagLogFileIndex = 0;
 
       public void run() {
-        jobStateManager.storeJSON(dagDirectory, String.valueOf(dagLogFileIndex++));
+        planStateManager.storeJSON(dagDirectory, String.valueOf(dagLogFileIndex++));
       }
     }, DAG_LOGGING_PERIOD, DAG_LOGGING_PERIOD, TimeUnit.MILLISECONDS);
 

--- a/runtime/master/src/main/java/edu/snu/nemo/runtime/master/eventhandler/UpdatePhysicalPlanEventHandler.java
+++ b/runtime/master/src/main/java/edu/snu/nemo/runtime/master/eventhandler/UpdatePhysicalPlanEventHandler.java
@@ -50,6 +50,6 @@ public final class UpdatePhysicalPlanEventHandler implements CompilerEventHandle
     final PhysicalPlan newPlan = updatePhysicalPlanEvent.getNewPhysicalPlan();
     final Pair<String, String> taskInfo = updatePhysicalPlanEvent.getTaskInfo();
 
-    this.scheduler.updateJob(newPlan.getId(), newPlan, taskInfo);
+    this.scheduler.updatePlan(newPlan.getId(), newPlan, taskInfo);
   }
 }

--- a/runtime/master/src/main/java/edu/snu/nemo/runtime/master/scheduler/BatchScheduler.java
+++ b/runtime/master/src/main/java/edu/snu/nemo/runtime/master/scheduler/BatchScheduler.java
@@ -96,15 +96,15 @@ public final class BatchScheduler implements Scheduler {
   }
 
   /**
-   * @param physicalPlan the physical plan to schedule.
-   * @param planStateManager the state manager of the plan.
+   * @param submittedPhysicalPlan the physical plan to schedule.
+   * @param submittedPlanStateManager the state manager of the plan.
    */
   @Override
-  public void schedulePlan(final PhysicalPlan physicalPlan, final PlanStateManager planStateManager) {
+  public void schedulePlan(final PhysicalPlan submittedPhysicalPlan, final PlanStateManager submittedPlanStateManager) {
     LOG.info("Scheduled plan");
 
-    this.physicalPlan = physicalPlan;
-    this.planStateManager = planStateManager;
+    this.physicalPlan = submittedPhysicalPlan;
+    this.planStateManager = submittedPlanStateManager;
 
     schedulerRunner.run(this.planStateManager);
     LOG.info("Plan to schedule: {}", this.physicalPlan.getId());

--- a/runtime/master/src/main/java/edu/snu/nemo/runtime/master/scheduler/BatchSingleJobScheduler.java
+++ b/runtime/master/src/main/java/edu/snu/nemo/runtime/master/scheduler/BatchSingleJobScheduler.java
@@ -101,9 +101,7 @@ public final class BatchSingleJobScheduler implements Scheduler {
    */
   @Override
   public void scheduleJob(final PhysicalPlan physicalPlanOfJob, final JobStateManager jobStateManagerOfJob) {
-    if (this.physicalPlan != null || this.jobStateManager != null) {
-      throw new IllegalStateException("scheduleJob() has been called more than once");
-    }
+    LOG.info("Scheduled job");
 
     this.physicalPlan = physicalPlanOfJob;
     this.jobStateManager = jobStateManagerOfJob;
@@ -111,11 +109,9 @@ public final class BatchSingleJobScheduler implements Scheduler {
     schedulerRunner.run(jobStateManager);
     LOG.info("Job to schedule: {}", this.physicalPlan.getId());
 
-    this.sortedScheduleGroups = this.physicalPlan.getStageDAG().getVertices()
-        .stream()
+    this.sortedScheduleGroups = this.physicalPlan.getStageDAG().getVertices().stream()
         .collect(Collectors.groupingBy(Stage::getScheduleGroup))
-        .entrySet()
-        .stream()
+        .entrySet().stream()
         .sorted(Map.Entry.comparingByKey())
         .map(Map.Entry::getValue)
         .collect(Collectors.toList());

--- a/runtime/master/src/main/java/edu/snu/nemo/runtime/master/scheduler/Scheduler.java
+++ b/runtime/master/src/main/java/edu/snu/nemo/runtime/master/scheduler/Scheduler.java
@@ -18,7 +18,7 @@ package edu.snu.nemo.runtime.master.scheduler;
 import edu.snu.nemo.common.Pair;
 import edu.snu.nemo.runtime.common.plan.PhysicalPlan;
 import edu.snu.nemo.runtime.common.state.TaskState;
-import edu.snu.nemo.runtime.master.JobStateManager;
+import edu.snu.nemo.runtime.master.PlanStateManager;
 import edu.snu.nemo.runtime.master.resource.ExecutorRepresenter;
 import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.tang.annotations.DefaultImplementation;
@@ -38,10 +38,10 @@ public interface Scheduler {
   /**
    * Schedules the given job.
    * @param physicalPlan of the job being submitted.
-   * @param jobStateManager to manage the states of the submitted job.
+   * @param planStateManager to manage the states of the submitted job.
    */
   void scheduleJob(PhysicalPlan physicalPlan,
-                   JobStateManager jobStateManager);
+                   PlanStateManager planStateManager);
 
   /**
    * Receives and updates the scheduler with a new physical plan for a job.

--- a/runtime/master/src/main/java/edu/snu/nemo/runtime/master/scheduler/Scheduler.java
+++ b/runtime/master/src/main/java/edu/snu/nemo/runtime/master/scheduler/Scheduler.java
@@ -32,25 +32,25 @@ import javax.annotation.Nullable;
  * Other scheduler-related classes that are accessed by only one of the two threads are not synchronized(NotThreadSafe).
  */
 @DriverSide
-@DefaultImplementation(BatchSingleJobScheduler.class)
+@DefaultImplementation(BatchScheduler.class)
 public interface Scheduler {
 
   /**
-   * Schedules the given job.
+   * Schedules the given plan.
    * @param physicalPlan of the job being submitted.
-   * @param planStateManager to manage the states of the submitted job.
+   * @param planStateManager to manage the states of the submitted plan.
    */
-  void scheduleJob(PhysicalPlan physicalPlan,
-                   PlanStateManager planStateManager);
+  void schedulePlan(PhysicalPlan physicalPlan,
+                    PlanStateManager planStateManager);
 
   /**
    * Receives and updates the scheduler with a new physical plan for a job.
-   * @param jobId the ID of the job to change the physical plan.
+   * @param planId the ID of the physical plan to change.
    * @param newPhysicalPlan new physical plan for the job.
    * @param taskInfo pair containing the information of the executor id and task id to mark as complete after the
    *                 update.
    */
-  void updateJob(String jobId, PhysicalPlan newPhysicalPlan, Pair<String, String> taskInfo);
+  void updatePlan(String planId, PhysicalPlan newPhysicalPlan, Pair<String, String> taskInfo);
 
   /**
    * Called when an executor is added to Runtime, so that the extra resource can be used to execute the job.

--- a/runtime/master/src/main/java/edu/snu/nemo/runtime/master/scheduler/SchedulerRunner.java
+++ b/runtime/master/src/main/java/edu/snu/nemo/runtime/master/scheduler/SchedulerRunner.java
@@ -23,6 +23,7 @@ import org.apache.commons.lang3.mutable.MutableObject;
 import org.apache.reef.annotations.audience.DriverSide;
 
 import java.util.*;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.locks.Condition;

--- a/runtime/master/src/main/java/edu/snu/nemo/runtime/master/scheduler/SchedulerRunner.java
+++ b/runtime/master/src/main/java/edu/snu/nemo/runtime/master/scheduler/SchedulerRunner.java
@@ -46,7 +46,7 @@ import javax.inject.Inject;
 @NotThreadSafe
 public final class SchedulerRunner {
   private static final Logger LOG = LoggerFactory.getLogger(SchedulerRunner.class.getName());
-  private final Map<String, PlanStateManager> jobStateManagers;
+  private final Map<String, PlanStateManager> planStateManagers;
   private final PendingTaskCollectionPointer pendingTaskCollectionPointer;
   private final ExecutorService schedulerThread;
   private boolean isSchedulerRunning;
@@ -62,7 +62,7 @@ public final class SchedulerRunner {
                           final SchedulingPolicy schedulingPolicy,
                           final PendingTaskCollectionPointer pendingTaskCollectionPointer,
                           final ExecutorRegistry executorRegistry) {
-    this.jobStateManagers = new HashMap<>();
+    this.planStateManagers = new HashMap<>();
     this.pendingTaskCollectionPointer = pendingTaskCollectionPointer;
     this.schedulerThread = Executors.newSingleThreadExecutor(runnable ->
         new Thread(runnable, "SchedulerRunner thread"));
@@ -84,11 +84,11 @@ public final class SchedulerRunner {
         doScheduleTaskList();
         schedulingIteration.await();
       }
-      jobStateManagers.values().forEach(jobStateManager -> {
-        if (jobStateManager.isJobDone()) {
-          LOG.info("{} is complete.", jobStateManager.getPlanId());
+      planStateManagers.values().forEach(planStateManager -> {
+        if (planStateManager.isPlanDone()) {
+          LOG.info("{} is complete.", planStateManager.getPlanId());
         } else {
-          LOG.info("{} is incomplete.", jobStateManager.getPlanId());
+          LOG.info("{} is incomplete.", planStateManager.getPlanId());
         }
       });
       LOG.info("SchedulerRunner Terminated!");
@@ -106,7 +106,7 @@ public final class SchedulerRunner {
     final Collection<Task> taskList = taskListOptional.get();
     final List<Task> couldNotSchedule = new ArrayList<>();
     for (final Task task : taskList) {
-      final PlanStateManager planStateManager = jobStateManagers.get(task.getPlanId());
+      final PlanStateManager planStateManager = planStateManagers.get(task.getPlanId());
       if (!planStateManager.getTaskState(task.getTaskId()).equals(TaskState.State.READY)) {
         // Guard against race conditions causing duplicate task launches
         LOG.debug("Skipping {} as it is not READY", task.getTaskId());
@@ -165,7 +165,7 @@ public final class SchedulerRunner {
    * Run the scheduler thread.
    */
   void run(final PlanStateManager planStateManager) {
-    jobStateManagers.put(planStateManager.getPlanId(), planStateManager);
+    planStateManagers.put(planStateManager.getPlanId(), planStateManager);
     if (!isTerminated && !isSchedulerRunning) {
       schedulerThread.execute(new SchedulerThread());
       schedulerThread.shutdown();

--- a/runtime/master/src/test/java/edu/snu/nemo/runtime/master/PlanStateManagerTest.java
+++ b/runtime/master/src/test/java/edu/snu/nemo/runtime/master/PlanStateManagerTest.java
@@ -22,7 +22,7 @@ import edu.snu.nemo.runtime.common.message.local.LocalMessageDispatcher;
 import edu.snu.nemo.runtime.common.message.local.LocalMessageEnvironment;
 import edu.snu.nemo.runtime.common.plan.PhysicalPlan;
 import edu.snu.nemo.runtime.common.plan.Stage;
-import edu.snu.nemo.runtime.common.state.JobState;
+import edu.snu.nemo.runtime.common.state.PlanState;
 import edu.snu.nemo.runtime.common.state.StageState;
 import edu.snu.nemo.runtime.common.state.TaskState;
 import edu.snu.nemo.runtime.common.plan.TestPlanGenerator;
@@ -42,11 +42,11 @@ import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.mock;
 
 /**
- * Tests {@link JobStateManager}.
+ * Tests {@link PlanStateManager}.
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(MetricMessageHandler.class)
-public final class JobStateManagerTest {
+public final class PlanStateManagerTest {
   private static final int MAX_SCHEDULE_ATTEMPT = 2;
   private MetricMessageHandler metricMessageHandler;
 
@@ -59,17 +59,17 @@ public final class JobStateManagerTest {
   }
 
   /**
-   * This method builds a physical DAG starting from an IR DAG and submits it to {@link JobStateManager}.
+   * This method builds a physical DAG starting from an IR DAG and submits it to {@link PlanStateManager}.
    * State changes are explicitly called to check whether states are managed correctly or not.
    */
   @Test
   public void testPhysicalPlanStateChanges() throws Exception {
     final PhysicalPlan physicalPlan =
         TestPlanGenerator.generatePhysicalPlan(TestPlanGenerator.PlanType.TwoVerticesJoined, false);
-    final JobStateManager jobStateManager =
-        new JobStateManager(physicalPlan, metricMessageHandler, MAX_SCHEDULE_ATTEMPT);
+    final PlanStateManager planStateManager =
+        new PlanStateManager(physicalPlan, metricMessageHandler, MAX_SCHEDULE_ATTEMPT);
 
-    assertEquals(jobStateManager.getJobId(), "TestPlan");
+    assertEquals(planStateManager.getPlanId(), "TestPlan");
 
     final List<Stage> stageList = physicalPlan.getStageDAG().getTopologicalSort();
 
@@ -77,16 +77,16 @@ public final class JobStateManagerTest {
       final Stage stage = stageList.get(stageIdx);
       final List<String> taskIds = stage.getTaskIds();
       taskIds.forEach(taskId -> {
-        jobStateManager.onTaskStateChanged(taskId, TaskState.State.EXECUTING);
-        jobStateManager.onTaskStateChanged(taskId, TaskState.State.COMPLETE);
+        planStateManager.onTaskStateChanged(taskId, TaskState.State.EXECUTING);
+        planStateManager.onTaskStateChanged(taskId, TaskState.State.COMPLETE);
         if (RuntimeIdGenerator.getIndexFromTaskId(taskId) == taskIds.size() - 1) {
-          assertEquals(StageState.State.COMPLETE, jobStateManager.getStageState(stage.getId()));
+          assertEquals(StageState.State.COMPLETE, planStateManager.getStageState(stage.getId()));
         }
       });
-      taskIds.forEach(taskId -> assertEquals(jobStateManager.getTaskState(taskId), TaskState.State.COMPLETE));
+      taskIds.forEach(taskId -> assertEquals(planStateManager.getTaskState(taskId), TaskState.State.COMPLETE));
 
       if (stageIdx == stageList.size() - 1) {
-        assertEquals(jobStateManager.getJobState(), JobState.State.COMPLETE);
+        assertEquals(planStateManager.getPlanState(), PlanState.State.COMPLETE);
       }
     }
   }
@@ -98,24 +98,24 @@ public final class JobStateManagerTest {
   public void testWaitUntilFinish() throws Exception {
     final PhysicalPlan physicalPlan =
         TestPlanGenerator.generatePhysicalPlan(TestPlanGenerator.PlanType.TwoVerticesJoined, false);
-    final JobStateManager jobStateManager =
-        new JobStateManager(physicalPlan, metricMessageHandler, MAX_SCHEDULE_ATTEMPT);
+    final PlanStateManager planStateManager =
+        new PlanStateManager(physicalPlan, metricMessageHandler, MAX_SCHEDULE_ATTEMPT);
 
-    assertFalse(jobStateManager.isJobDone());
+    assertFalse(planStateManager.isJobDone());
 
     // Wait for the job to finish and check the job state.
     // It have to return EXECUTING state after timeout.
-    final JobState.State executingState = jobStateManager.waitUntilFinish(100, TimeUnit.MILLISECONDS);
-    assertEquals(JobState.State.EXECUTING, executingState);
+    final PlanState.State executingState = planStateManager.waitUntilFinish(100, TimeUnit.MILLISECONDS);
+    assertEquals(PlanState.State.EXECUTING, executingState);
 
     // Complete the job and check the result again.
     // It have to return COMPLETE.
     final List<String> tasks = physicalPlan.getStageDAG().getTopologicalSort().stream()
         .flatMap(stage -> stage.getTaskIds().stream())
         .collect(Collectors.toList());
-    tasks.forEach(taskId -> jobStateManager.onTaskStateChanged(taskId, TaskState.State.EXECUTING));
-    tasks.forEach(taskId -> jobStateManager.onTaskStateChanged(taskId, TaskState.State.COMPLETE));
-    final JobState.State completedState = jobStateManager.waitUntilFinish();
-    assertEquals(JobState.State.COMPLETE, completedState);
+    tasks.forEach(taskId -> planStateManager.onTaskStateChanged(taskId, TaskState.State.EXECUTING));
+    tasks.forEach(taskId -> planStateManager.onTaskStateChanged(taskId, TaskState.State.COMPLETE));
+    final PlanState.State completedState = planStateManager.waitUntilFinish();
+    assertEquals(PlanState.State.COMPLETE, completedState);
   }
 }

--- a/runtime/master/src/test/java/edu/snu/nemo/runtime/master/PlanStateManagerTest.java
+++ b/runtime/master/src/test/java/edu/snu/nemo/runtime/master/PlanStateManagerTest.java
@@ -92,7 +92,7 @@ public final class PlanStateManagerTest {
   }
 
   /**
-   * Test whether the methods waiting finish of job works properly.
+   * Test whether the methods waiting for the finish of the plan works properly.
    */
   @Test(timeout = 2000)
   public void testWaitUntilFinish() throws Exception {
@@ -101,15 +101,15 @@ public final class PlanStateManagerTest {
     final PlanStateManager planStateManager =
         new PlanStateManager(physicalPlan, metricMessageHandler, MAX_SCHEDULE_ATTEMPT);
 
-    assertFalse(planStateManager.isJobDone());
+    assertFalse(planStateManager.isPlanDone());
 
-    // Wait for the job to finish and check the job state.
+    // Wait for the plan to finish and check the plan state.
     // It have to return EXECUTING state after timeout.
     final PlanState.State executingState = planStateManager.waitUntilFinish(100, TimeUnit.MILLISECONDS);
     assertEquals(PlanState.State.EXECUTING, executingState);
 
-    // Complete the job and check the result again.
-    // It have to return COMPLETE.
+    // Complete the plan and check the result again.
+    // It has to return COMPLETE.
     final List<String> tasks = physicalPlan.getStageDAG().getTopologicalSort().stream()
         .flatMap(stage -> stage.getTaskIds().stream())
         .collect(Collectors.toList());

--- a/runtime/master/src/test/java/edu/snu/nemo/runtime/master/scheduler/BatchSchedulerTest.java
+++ b/runtime/master/src/test/java/edu/snu/nemo/runtime/master/scheduler/BatchSchedulerTest.java
@@ -54,13 +54,13 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
 /**
- * Tests {@link BatchSingleJobScheduler}.
+ * Tests {@link BatchScheduler}.
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ContainerManager.class, BlockManagerMaster.class,
     PubSubEventHandlerWrapper.class, UpdatePhysicalPlanEventHandler.class, MetricMessageHandler.class})
-public final class BatchSingleJobSchedulerTest {
-  private static final Logger LOG = LoggerFactory.getLogger(BatchSingleJobSchedulerTest.class.getName());
+public final class BatchSchedulerTest {
+  private static final Logger LOG = LoggerFactory.getLogger(BatchSchedulerTest.class.getName());
   private Scheduler scheduler;
   private ExecutorRegistry executorRegistry;
   private final MetricMessageHandler metricMessageHandler = mock(MetricMessageHandler.class);
@@ -80,7 +80,7 @@ public final class BatchSingleJobSchedulerTest {
     injector.bindVolatileInstance(BlockManagerMaster.class, mock(BlockManagerMaster.class));
     injector.bindVolatileInstance(PubSubEventHandlerWrapper.class, mock(PubSubEventHandlerWrapper.class));
     injector.bindVolatileInstance(UpdatePhysicalPlanEventHandler.class, mock(UpdatePhysicalPlanEventHandler.class));
-    scheduler = injector.getInstance(BatchSingleJobScheduler.class);
+    scheduler = injector.getInstance(BatchScheduler.class);
 
     final ActiveContext activeContext = mock(ActiveContext.class);
     Mockito.doThrow(new RuntimeException()).when(activeContext).close();
@@ -114,28 +114,28 @@ public final class BatchSingleJobSchedulerTest {
   }
 
   /**
-   * This method builds a physical DAG starting from an IR DAG and submits it to {@link BatchSingleJobScheduler}.
+   * This method builds a physical DAG starting from an IR DAG and submits it to {@link BatchScheduler}.
    * Task state changes are explicitly submitted to scheduler instead of executor messages.
    */
   @Test(timeout=10000)
   public void testPull() throws Exception {
-    scheduleAndCheckJobTermination(
+    scheduleAndCheckPlanTermination(
         TestPlanGenerator.generatePhysicalPlan(TestPlanGenerator.PlanType.TwoVerticesJoined, false));
   }
 
   /**
-   * This method builds a physical DAG starting from an IR DAG and submits it to {@link BatchSingleJobScheduler}.
+   * This method builds a physical DAG starting from an IR DAG and submits it to {@link BatchScheduler}.
    * Task state changes are explicitly submitted to scheduler instead of executor messages.
    */
   @Test(timeout=10000)
   public void testPush() throws Exception {
-    scheduleAndCheckJobTermination(
+    scheduleAndCheckPlanTermination(
         TestPlanGenerator.generatePhysicalPlan(TestPlanGenerator.PlanType.TwoVerticesJoined, true));
   }
 
-  private void scheduleAndCheckJobTermination(final PhysicalPlan plan) throws InjectionException {
+  private void scheduleAndCheckPlanTermination(final PhysicalPlan plan) throws InjectionException {
     final PlanStateManager planStateManager = new PlanStateManager(plan, metricMessageHandler, 1);
-    scheduler.scheduleJob(plan, planStateManager);
+    scheduler.schedulePlan(plan, planStateManager);
 
     // For each ScheduleGroup, test if the tasks of the next ScheduleGroup are scheduled
     // after the stages of each ScheduleGroup are made "complete".
@@ -150,10 +150,10 @@ public final class BatchSingleJobSchedulerTest {
       });
     }
 
-    LOG.debug("Waiting for job termination after sending stage completion events");
-    while (!planStateManager.isJobDone()) {
+    LOG.debug("Waiting for plan termination after sending stage completion events");
+    while (!planStateManager.isPlanDone()) {
     }
-    assertTrue(planStateManager.isJobDone());
+    assertTrue(planStateManager.isPlanDone());
   }
 
   private List<Stage> filterStagesWithAScheduleGroup(

--- a/runtime/master/src/test/java/edu/snu/nemo/runtime/master/scheduler/BatchSingleJobSchedulerTest.java
+++ b/runtime/master/src/test/java/edu/snu/nemo/runtime/master/scheduler/BatchSingleJobSchedulerTest.java
@@ -23,7 +23,7 @@ import edu.snu.nemo.runtime.common.message.MessageSender;
 import edu.snu.nemo.runtime.common.plan.PhysicalPlan;
 import edu.snu.nemo.runtime.common.plan.Stage;
 import edu.snu.nemo.runtime.common.plan.StageEdge;
-import edu.snu.nemo.runtime.master.JobStateManager;
+import edu.snu.nemo.runtime.master.PlanStateManager;
 import edu.snu.nemo.runtime.master.MetricMessageHandler;
 import edu.snu.nemo.runtime.master.BlockManagerMaster;
 import edu.snu.nemo.runtime.master.eventhandler.UpdatePhysicalPlanEventHandler;
@@ -134,8 +134,8 @@ public final class BatchSingleJobSchedulerTest {
   }
 
   private void scheduleAndCheckJobTermination(final PhysicalPlan plan) throws InjectionException {
-    final JobStateManager jobStateManager = new JobStateManager(plan, metricMessageHandler, 1);
-    scheduler.scheduleJob(plan, jobStateManager);
+    final PlanStateManager planStateManager = new PlanStateManager(plan, metricMessageHandler, 1);
+    scheduler.scheduleJob(plan, planStateManager);
 
     // For each ScheduleGroup, test if the tasks of the next ScheduleGroup are scheduled
     // after the stages of each ScheduleGroup are made "complete".
@@ -146,14 +146,14 @@ public final class BatchSingleJobSchedulerTest {
       LOG.debug("Checking that all stages of ScheduleGroup {} enter the executing state", scheduleGroupIdx);
       stages.forEach(stage -> {
         SchedulerTestUtil.completeStage(
-            jobStateManager, scheduler, executorRegistry, stage, SCHEDULE_ATTEMPT_INDEX);
+            planStateManager, scheduler, executorRegistry, stage, SCHEDULE_ATTEMPT_INDEX);
       });
     }
 
     LOG.debug("Waiting for job termination after sending stage completion events");
-    while (!jobStateManager.isJobDone()) {
+    while (!planStateManager.isJobDone()) {
     }
-    assertTrue(jobStateManager.isJobDone());
+    assertTrue(planStateManager.isJobDone());
   }
 
   private List<Stage> filterStagesWithAScheduleGroup(

--- a/runtime/master/src/test/java/edu/snu/nemo/runtime/master/scheduler/SchedulerTestUtil.java
+++ b/runtime/master/src/test/java/edu/snu/nemo/runtime/master/scheduler/SchedulerTestUtil.java
@@ -29,8 +29,8 @@ import java.util.Optional;
 final class SchedulerTestUtil {
   /**
    * Complete the stage by completing all of its Tasks.
-   * @param planStateManager for the submitted job.
-   * @param scheduler for the submitted job.
+   * @param planStateManager for the submitted plan.
+   * @param scheduler for the submitted plan.
    * @param executorRegistry provides executor representers
    * @param stage for which the states should be marked as complete.
    */
@@ -66,7 +66,7 @@ final class SchedulerTestUtil {
   /**
    * Sends task state change event to scheduler.
    * This replaces executor's task completion messages for testing purposes.
-   * @param scheduler for the submitted job.
+   * @param scheduler for the submitted plan.
    * @param executorRegistry provides executor representers
    * @param taskId for the task to change the state.
    * @param newState for the task.

--- a/runtime/master/src/test/java/edu/snu/nemo/runtime/master/scheduler/SchedulerTestUtil.java
+++ b/runtime/master/src/test/java/edu/snu/nemo/runtime/master/scheduler/SchedulerTestUtil.java
@@ -18,7 +18,7 @@ package edu.snu.nemo.runtime.master.scheduler;
 import edu.snu.nemo.runtime.common.plan.Stage;
 import edu.snu.nemo.runtime.common.state.StageState;
 import edu.snu.nemo.runtime.common.state.TaskState;
-import edu.snu.nemo.runtime.master.JobStateManager;
+import edu.snu.nemo.runtime.master.PlanStateManager;
 import edu.snu.nemo.runtime.master.resource.ExecutorRepresenter;
 
 import java.util.Optional;
@@ -29,25 +29,25 @@ import java.util.Optional;
 final class SchedulerTestUtil {
   /**
    * Complete the stage by completing all of its Tasks.
-   * @param jobStateManager for the submitted job.
+   * @param planStateManager for the submitted job.
    * @param scheduler for the submitted job.
    * @param executorRegistry provides executor representers
    * @param stage for which the states should be marked as complete.
    */
-  static void completeStage(final JobStateManager jobStateManager,
+  static void completeStage(final PlanStateManager planStateManager,
                             final Scheduler scheduler,
                             final ExecutorRegistry executorRegistry,
                             final Stage stage,
                             final int attemptIdx) {
     // Loop until the stage completes.
     while (true) {
-      final StageState.State stageState = jobStateManager.getStageState(stage.getId());
+      final StageState.State stageState = planStateManager.getStageState(stage.getId());
       if (StageState.State.COMPLETE == stageState) {
         // Stage has completed, so we break out of the loop.
         break;
       } else if (StageState.State.INCOMPLETE == stageState) {
         stage.getTaskIds().forEach(taskId -> {
-          final TaskState.State taskState = jobStateManager.getTaskState(taskId);
+          final TaskState.State taskState = planStateManager.getTaskState(taskId);
           if (TaskState.State.EXECUTING == taskState) {
             sendTaskStateEventToScheduler(scheduler, executorRegistry, taskId,
                 TaskState.State.COMPLETE, attemptIdx, null);

--- a/runtime/master/src/test/java/edu/snu/nemo/runtime/master/scheduler/TaskRetryTest.java
+++ b/runtime/master/src/test/java/edu/snu/nemo/runtime/master/scheduler/TaskRetryTest.java
@@ -97,8 +97,8 @@ public final class TaskRetryTest {
 
   @Test(timeout=7000)
   public void testExecutorRemoved() throws Exception {
-    // Until the job finishes, events happen
-    while (!planStateManager.isJobDone()) {
+    // Until the plan finishes, events happen
+    while (!planStateManager.isPlanDone()) {
       // 50% chance remove, 50% chance add, 80% chance task completed
       executorRemoved(0.5);
       executorAdded(0.5);
@@ -108,9 +108,9 @@ public final class TaskRetryTest {
       Thread.sleep(10);
     }
 
-    // Job should COMPLETE
+    // Plan should COMPLETE
     assertEquals(PlanState.State.COMPLETE, planStateManager.getPlanState());
-    assertTrue(planStateManager.isJobDone());
+    assertTrue(planStateManager.isPlanDone());
   }
 
   @Test(timeout=7000)
@@ -120,8 +120,8 @@ public final class TaskRetryTest {
     executorAdded(1.0);
     executorAdded(1.0);
 
-    // Until the job finishes, events happen
-    while (!planStateManager.isJobDone()) {
+    // Until the plan finishes, events happen
+    while (!planStateManager.isPlanDone()) {
       // 50% chance task completed
       // 50% chance task output write failed
       taskCompleted(0.5);
@@ -131,9 +131,9 @@ public final class TaskRetryTest {
       Thread.sleep(10);
     }
 
-    // Job should COMPLETE
+    // Plan should COMPLETE
     assertEquals(PlanState.State.COMPLETE, planStateManager.getPlanState());
-    assertTrue(planStateManager.isJobDone());
+    assertTrue(planStateManager.isPlanDone());
   }
 
   ////////////////////////////////////////////////////////////////// Events
@@ -214,7 +214,7 @@ public final class TaskRetryTest {
     final MetricMessageHandler metricMessageHandler = mock(MetricMessageHandler.class);
     final PhysicalPlan plan = TestPlanGenerator.generatePhysicalPlan(planType, false);
     final PlanStateManager planStateManager = new PlanStateManager(plan, metricMessageHandler, MAX_SCHEDULE_ATTEMPT);
-    scheduler.scheduleJob(plan, planStateManager);
+    scheduler.schedulePlan(plan, planStateManager);
     return planStateManager;
   }
 }

--- a/runtime/test/src/main/java/edu/snu/nemo/runtime/common/plan/TestPlanGenerator.java
+++ b/runtime/test/src/main/java/edu/snu/nemo/runtime/common/plan/TestPlanGenerator.java
@@ -94,7 +94,7 @@ public final class TestPlanGenerator {
   private static PhysicalPlan convertIRToPhysical(final DAG<IRVertex, IREdge> irDAG,
                                                   final Policy policy) throws Exception {
     final DAG<IRVertex, IREdge> optimized = policy.runCompileTimeOptimization(irDAG, EMPTY_DAG_DIRECTORY);
-    final DAG<Stage, StageEdge> physicalDAG = optimized.convert(PLAN_GENERATOR);
+    final DAG<Stage, StageEdge> physicalDAG = PLAN_GENERATOR.apply(optimized);
     return new PhysicalPlan("TestPlan", physicalDAG);
   }
 


### PR DESCRIPTION
JIRA: [NEMO-152: Support Multiple DAGs Execution in a Single User Program](https://issues.apache.org/jira/projects/NEMO/issues/NEMO-152)

**Major changes:**
- Divides the usage of the word 'Job' and 'Plan' to be more specific about what is being run. Before, a job had a single physical plan, so it was possible to use them with an identical name, but as jobs can contain multiple physical plans, it was necessary to divide them
- Fixes the scheduler and the scheduler runner to accept multiple physical plans

**Minor changes to note:**
- Grammatical errors on the comments
- The convert method on the DAG had almost no usages, and it was misleading on the way it was used, so it was removed.
- I've allowed multiple spark contexts on an evaluator, so that an evaluator can be reused for multiple physical plans.

**Tests for the changes:**
- A sample program, performing a line count on one execution, and then word count on another, is added as an integration test. All existing tests pass with the changes.

**Other comments:**
- N/A

resolves [NEMO-152](https://issues.apache.org/jira/projects/NEMO/issues/NEMO-152)