### PR TITLE
[NEMO-177] Fix BytesDecoder to handle empty stream properly

### DIFF
--- a/common/src/main/java/edu/snu/nemo/common/coder/BytesDecoderFactory.java
+++ b/common/src/main/java/edu/snu/nemo/common/coder/BytesDecoderFactory.java
@@ -52,6 +52,7 @@ public final class BytesDecoderFactory implements DecoderFactory<byte[]> {
   private final class BytesDecoder implements Decoder<byte[]> {
 
     private final InputStream inputStream;
+    private boolean returnedArray;
 
     /**
      * Constructor.
@@ -60,6 +61,7 @@ public final class BytesDecoderFactory implements DecoderFactory<byte[]> {
      */
     private BytesDecoder(final InputStream inputStream) {
       this.inputStream = inputStream;
+      this.returnedArray = false;
     }
 
     @Override
@@ -75,11 +77,17 @@ public final class BytesDecoderFactory implements DecoderFactory<byte[]> {
 
       final int lengthToRead = byteOutputStream.getCount();
       if (lengthToRead == 0) {
-        throw new IOException("EoF (empty partition)!"); // TODO #120: use EOF exception instead of IOException.
+        if (!returnedArray) {
+          returnedArray = true;
+          return new byte[0];
+        } else {
+          throw new IOException("EoF (empty partition)!"); // TODO #120: use EOF exception instead of IOException.
+        }
       }
       final byte[] resultBytes = new byte[lengthToRead]; // Read the size of this byte array.
       System.arraycopy(byteOutputStream.getBufDirectly(), 0, resultBytes, 0, lengthToRead);
 
+      returnedArray = true;
       return resultBytes;
     }
   }

--- a/common/src/test/java/edu/snu/nemo/common/coder/CoderFactoryTest.java
+++ b/common/src/test/java/edu/snu/nemo/common/coder/CoderFactoryTest.java
@@ -18,7 +18,6 @@ package edu.snu.nemo.common.coder;
 
 import edu.snu.nemo.common.ContextImpl;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
@@ -28,10 +27,6 @@ import java.io.ByteArrayOutputStream;
  * Tests {@link ContextImpl}.
  */
 public class CoderFactoryTest {
-
-  @Before
-  public void setUp() {
-  }
 
   @Test
   public void testBytesCoderFactories() throws Exception {

--- a/common/src/test/java/edu/snu/nemo/common/coder/CoderFactoryTest.java
+++ b/common/src/test/java/edu/snu/nemo/common/coder/CoderFactoryTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2018 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package edu.snu.nemo.common.coder;
+
+import edu.snu.nemo.common.ContextImpl;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+
+/**
+ * Tests {@link ContextImpl}.
+ */
+public class CoderFactoryTest {
+
+  @Before
+  public void setUp() {
+  }
+
+  @Test
+  public void testBytesCoderFactories() throws Exception {
+    final BytesEncoderFactory encoderFactory = BytesEncoderFactory.of();
+    final BytesDecoderFactory decoderFactory = BytesDecoderFactory.of();
+
+    // Test empty bytes.
+    byte[] elementToTest = new byte[0];
+    byte[] decodedBytes = encodeAndDecodeElement(encoderFactory, decoderFactory, elementToTest);
+    Assert.assertArrayEquals(elementToTest, decodedBytes);
+
+    // Test filled bytes.
+    elementToTest = "Hello NEMO!".getBytes();
+    decodedBytes = encodeAndDecodeElement(encoderFactory, decoderFactory, elementToTest);
+    Assert.assertArrayEquals(elementToTest, decodedBytes);
+  }
+
+  /**
+   * Encode and decode an element through the given factories and return the result elements.
+   *
+   * @param encoderFactory the encoder factory to test.
+   * @param decoderFactory the decoder factory to test.
+   * @param element        the element to test.
+   * @param <T>            the type of the element.
+   * @return the decoded element.
+   */
+  private <T> T encodeAndDecodeElement(final EncoderFactory<T> encoderFactory,
+                                                     final DecoderFactory<T> decoderFactory,
+                                                     final T element) throws Exception {
+    final byte[] encodedElement;
+    try (final ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+      final EncoderFactory.Encoder<T> encoder = encoderFactory.create(out);
+      encoder.encode(element);
+      encodedElement = out.toByteArray();
+    }
+
+    final T decodedElement;
+    try (final ByteArrayInputStream in = new ByteArrayInputStream(encodedElement)) {
+      final DecoderFactory.Decoder<T> decoder = decoderFactory.create(in);
+      decodedElement = decoder.decode();
+    }
+
+    return decodedElement;
+  }
+}


### PR DESCRIPTION
JIRA: [NEMO-177: Fix BytesDecoder to handle empty stream properly](https://issues.apache.org/jira/projects/NEMO/issues/NEMO-177)

**Major changes:**
- Make `BytesDecoder` of `BytesDecoderFactory` to return empty byte[] at first, and throw EoF for the next time if it receives empty byte array.

**Minor changes to note:**
- N/A.

**Tests for the changes:**
- Add `CoderFactoryTest` to test this feature.

**Other comments:**
- N/A.

resolves [NEMO-177](https://issues.apache.org/jira/projects/NEMO/issues/NEMO-177)
