### PR TITLE
[NEMO-184] Upgrade to Beam 2.6.0

### DIFF
--- a/compiler/frontend/beam/src/main/java/edu/snu/nemo/compiler/frontend/beam/transform/DoTransform.java
+++ b/compiler/frontend/beam/src/main/java/edu/snu/nemo/compiler/frontend/beam/transform/DoTransform.java
@@ -31,6 +31,7 @@ import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
 import org.apache.beam.sdk.transforms.windowing.PaneInfo;
 import org.apache.beam.sdk.values.PCollectionView;
+import org.apache.beam.sdk.values.Row;
 import org.apache.beam.sdk.values.TupleTag;
 import org.joda.time.Instant;
 
@@ -241,6 +242,11 @@ public final class DoTransform<I, O> implements Transform<I, O> {
     }
 
     @Override
+    public Row asRow(final String id) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
     public <T> T sideInput(final PCollectionView<T> view) {
       return (T) sideInputs.get(view);
     }
@@ -355,6 +361,11 @@ public final class DoTransform<I, O> implements Transform<I, O> {
     }
 
     @Override
+    public DoFn.OutputReceiver<Row> outputRowReceiver(final DoFn<I, O> doFn) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
     public DoFn.MultiOutputReceiver taggedOutputReceiver(final DoFn<I, O> doFn) {
       return new MultiOutputReceiver((OutputCollectorImpl) outputCollector, additionalOutputs);
     }
@@ -431,6 +442,11 @@ public final class DoTransform<I, O> implements Transform<I, O> {
     @Override
     public <T> DoFn.OutputReceiver<T> get(final TupleTag<T> tag) {
       return new OutputReceiver<>(this.outputCollector, tag, tagToVertex);
+    }
+
+    @Override
+    public <T> OutputReceiver<Row> getRowReceiver(final TupleTag<T> tag) {
+      throw new UnsupportedOperationException();
     }
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ limitations under the License.
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <beam.version>2.5.0</beam.version>
+        <beam.version>2.6.0</beam.version>
         <spark.version>2.2.0</spark.version>
         <scala.version>2.11.8</scala.version>
         <kryo.version>4.0.1</kryo.version>


### PR DESCRIPTION
JIRA: [NEMO-184: Upgrade to Beam 2.6.0](https://issues.apache.org/jira/projects/NEMO/issues/NEMO-184)

**Major changes:**
- Upgrade to Beam 2.6.0

**Minor changes to note:**
- N/A

**Tests for the changes:**
- N/A (just a version upgrade)

**Other comments:**
- throw UnsupportedException when the new Row-related APIs are called

resolves [NEMO-184](https://issues.apache.org/jira/projects/NEMO/issues/NEMO-184)
