### PR TITLE
[NEMO-89] Clean up IRVertex#getClone()

### DIFF
--- a/common/src/main/java/edu/snu/nemo/common/Cloneable.java
+++ b/common/src/main/java/edu/snu/nemo/common/Cloneable.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2018 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.nemo.common;
+
+/**
+ * This interface is implemented by objects that can be cloned.
+ * <p>
+ * This interface also overcomes the drawback of {@link java.lang.Cloneable} interface which
+ * doesn't have a clone method.
+ * Josh Bloch (a JDK author) has pointed out this in his book "Effective Java" as
+ * <a href="http://thefinestartist.com/effective-java/11"> Override clone judiciously </a>
+ * </p>
+ *
+ * @param <T> the type of objects that this class can clone
+ */
+public interface Cloneable<T extends Cloneable<T>> {
+
+  /**
+   * Creates and returns a copy of this object.
+   * <p>
+   * The precise meaning of "copy" may depend on the class of the object.
+   * The general intent is that, all fields of the object are copied.
+   * </p>
+   *
+   * @return a clone of this object.
+   */
+  T getClone();
+}

--- a/common/src/main/java/edu/snu/nemo/common/ir/vertex/IRVertex.java
+++ b/common/src/main/java/edu/snu/nemo/common/ir/vertex/IRVertex.java
@@ -19,6 +19,7 @@ import edu.snu.nemo.common.ir.IdManager;
 import edu.snu.nemo.common.ir.executionproperty.ExecutionPropertyMap;
 import edu.snu.nemo.common.dag.Vertex;
 import edu.snu.nemo.common.ir.executionproperty.VertexExecutionProperty;
+import edu.snu.nemo.common.Cloneable;
 
 import java.io.Serializable;
 import java.util.Optional;
@@ -27,7 +28,7 @@ import java.util.Optional;
  * The basic unit of operation in a dataflow program, as well as the most important data structure in Nemo.
  * An IRVertex is created and modified in the compiler, and executed in the runtime.
  */
-public abstract class IRVertex extends Vertex {
+public abstract class IRVertex extends Vertex implements Cloneable<IRVertex> {
   private final ExecutionPropertyMap<VertexExecutionProperty> executionProperties;
   private boolean stagePartitioned;
 
@@ -41,20 +42,19 @@ public abstract class IRVertex extends Vertex {
   }
 
   /**
-   * @return a clone elemnt of the IRVertex.
+   * Copy Constructor for IRVertex.
+   *
+   * @param that the source object for copying
    */
-  public abstract IRVertex getClone();
-
-  /**
-   * Static function to copy executionProperties from a vertex to the other.
-   * @param thatVertex the edge to copy executionProperties to.
-   */
-  public final void copyExecutionPropertiesTo(final IRVertex thatVertex) {
-    this.getExecutionProperties().forEachProperties(thatVertex::setProperty);
+  public IRVertex(final IRVertex that) {
+    super(that.getId());
+    this.executionProperties = that.executionProperties;
+    this.stagePartitioned = that.stagePartitioned;
   }
 
   /**
    * Set an executionProperty of the IRVertex.
+   *
    * @param executionProperty new execution property.
    * @return the IRVertex with the execution property set.
    */
@@ -65,6 +65,7 @@ public abstract class IRVertex extends Vertex {
 
   /**
    * Set an executionProperty of the IRVertex, permanently.
+   *
    * @param executionProperty new execution property.
    * @return the IRVertex with the execution property set.
    */

--- a/common/src/main/java/edu/snu/nemo/common/ir/vertex/IRVertex.java
+++ b/common/src/main/java/edu/snu/nemo/common/ir/vertex/IRVertex.java
@@ -47,9 +47,18 @@ public abstract class IRVertex extends Vertex implements Cloneable<IRVertex> {
    * @param that the source object for copying
    */
   public IRVertex(final IRVertex that) {
-    super(that.getId());
-    this.executionProperties = that.executionProperties;
+    super(IdManager.newVertexId());
+    this.executionProperties = ExecutionPropertyMap.of(this);
+    that.getExecutionProperties().forEachProperties(this::setProperty);
     this.stagePartitioned = that.stagePartitioned;
+  }
+
+  /**
+   * Static function to copy executionProperties from a vertex to the other.
+   * @param thatVertex the edge to copy executionProperties to.
+   */
+  public final void copyExecutionPropertiesTo(final IRVertex thatVertex) {
+    this.getExecutionProperties().forEachProperties(thatVertex::setProperty);
   }
 
   /**

--- a/common/src/main/java/edu/snu/nemo/common/ir/vertex/InMemorySourceVertex.java
+++ b/common/src/main/java/edu/snu/nemo/common/ir/vertex/InMemorySourceVertex.java
@@ -29,18 +29,28 @@ public final class InMemorySourceVertex<T> extends SourceVertex<T> {
   private Iterable<T> initializedSourceData;
 
   /**
-   * Constructor.
+   * Constructor for InMemorySourceVertex.
+   *
    * @param initializedSourceData the initial data object.
    */
   public InMemorySourceVertex(final Iterable<T> initializedSourceData) {
+    super();
     this.initializedSourceData = initializedSourceData;
+  }
+
+  /**
+   * Copy Constructor for InMemorySourceVertex.
+   *
+   * @param that the source object for copying
+   */
+  public InMemorySourceVertex(final InMemorySourceVertex that) {
+    super(that);
+    this.initializedSourceData = that.initializedSourceData;
   }
 
   @Override
   public InMemorySourceVertex<T> getClone() {
-    final InMemorySourceVertex<T> that = new InMemorySourceVertex<>(this.initializedSourceData);
-    this.copyExecutionPropertiesTo(that);
-    return that;
+    return new InMemorySourceVertex<>(this);
   }
 
   @Override

--- a/common/src/main/java/edu/snu/nemo/common/ir/vertex/LoopVertex.java
+++ b/common/src/main/java/edu/snu/nemo/common/ir/vertex/LoopVertex.java
@@ -63,27 +63,28 @@ public final class LoopVertex extends IRVertex {
     this.terminationCondition = (IntPredicate & Serializable) (integer -> false); // nothing much yet.
   }
 
+  /**
+   * Copy Constructor for LoopVertex.
+   *
+   * @param that the source object for copying
+   */
+  public LoopVertex(final LoopVertex that) {
+    super(that);
+    this.builder = that.builder;
+    this.compositeTransformFullName = that.compositeTransformFullName;
+    this.dagIncomingEdges = that.dagIncomingEdges;
+    this.iterativeIncomingEdges = that.iterativeIncomingEdges;
+    this.nonIterativeIncomingEdges = that.nonIterativeIncomingEdges;
+    this.dagOutgoingEdges = that.dagOutgoingEdges;
+    this.edgeWithLoopToEdgeWithInternalVertex = that.edgeWithLoopToEdgeWithInternalVertex;
+    this.edgeWithInternalVertexToEdgeWithLoop = that.edgeWithInternalVertexToEdgeWithLoop;
+    this.maxNumberOfIterations = that.maxNumberOfIterations;
+    this.terminationCondition = that.terminationCondition;
+  }
+
   @Override
   public LoopVertex getClone() {
-    final LoopVertex newLoopVertex = new LoopVertex(compositeTransformFullName);
-
-    // Copy all elements to the clone
-    final DAG<IRVertex, IREdge> dagToCopy = this.getDAG();
-    dagToCopy.topologicalDo(v -> {
-      newLoopVertex.getBuilder().addVertex(v, dagToCopy);
-      dagToCopy.getIncomingEdgesOf(v).forEach(newLoopVertex.getBuilder()::connectVertices);
-    });
-    this.dagIncomingEdges.forEach(((v, es) -> es.forEach(newLoopVertex::addDagIncomingEdge)));
-    this.iterativeIncomingEdges.forEach((v, es) -> es.forEach(newLoopVertex::addIterativeIncomingEdge));
-    this.nonIterativeIncomingEdges.forEach((v, es) -> es.forEach(newLoopVertex::addNonIterativeIncomingEdge));
-    this.dagOutgoingEdges.forEach(((v, es) -> es.forEach(newLoopVertex::addDagOutgoingEdge)));
-    this.edgeWithLoopToEdgeWithInternalVertex.forEach((eLoop, eInternal)
-        -> newLoopVertex.mapEdgeWithLoop(eLoop, eInternal));
-    newLoopVertex.setMaxNumberOfIterations(maxNumberOfIterations);
-    newLoopVertex.setTerminationCondition(terminationCondition);
-
-    this.copyExecutionPropertiesTo(newLoopVertex);
-    return newLoopVertex;
+    return new LoopVertex(this);
   }
 
   /**

--- a/common/src/main/java/edu/snu/nemo/common/ir/vertex/MetricCollectionBarrierVertex.java
+++ b/common/src/main/java/edu/snu/nemo/common/ir/vertex/MetricCollectionBarrierVertex.java
@@ -52,10 +52,12 @@ public final class MetricCollectionBarrierVertex<K, V> extends IRVertex {
    *
    * @param that the source object for copying
    */
-  public MetricCollectionBarrierVertex(final MetricCollectionBarrierVertex that) {
+  public MetricCollectionBarrierVertex(final MetricCollectionBarrierVertex<K, V> that) {
     super(that);
-    this.metricData = that.metricData;
-    this.blockIds = that.blockIds;
+    this.metricData = new HashMap<>();
+    that.metricData.forEach(this.metricData::put);
+    this.blockIds = new ArrayList<>();
+    that.blockIds.forEach(this.blockIds::add);
     this.dagSnapshot = that.dagSnapshot;
   }
 

--- a/common/src/main/java/edu/snu/nemo/common/ir/vertex/MetricCollectionBarrierVertex.java
+++ b/common/src/main/java/edu/snu/nemo/common/ir/vertex/MetricCollectionBarrierVertex.java
@@ -41,17 +41,27 @@ public final class MetricCollectionBarrierVertex<K, V> extends IRVertex {
    * Constructor for dynamic optimization vertex.
    */
   public MetricCollectionBarrierVertex() {
+    super();
     this.metricData = new HashMap<>();
     this.blockIds = new ArrayList<>();
     this.dagSnapshot = null;
   }
 
+  /**
+   * Constructor for dynamic optimization vertex.
+   *
+   * @param that the source object for copying
+   */
+  public MetricCollectionBarrierVertex(final MetricCollectionBarrierVertex that) {
+    super(that);
+    this.metricData = that.metricData;
+    this.blockIds = that.blockIds;
+    this.dagSnapshot = that.dagSnapshot;
+  }
+
   @Override
   public MetricCollectionBarrierVertex getClone() {
-    final MetricCollectionBarrierVertex that = new MetricCollectionBarrierVertex();
-    that.setDAGSnapshot(dagSnapshot);
-    this.copyExecutionPropertiesTo(that);
-    return that;
+    return new MetricCollectionBarrierVertex(this);
   }
 
   /**

--- a/common/src/main/java/edu/snu/nemo/common/ir/vertex/OperatorVertex.java
+++ b/common/src/main/java/edu/snu/nemo/common/ir/vertex/OperatorVertex.java
@@ -26,6 +26,7 @@ public final class OperatorVertex extends IRVertex {
 
   /**
    * Constructor of OperatorVertex.
+   *
    * @param t transform for the OperatorVertex.
    */
   public OperatorVertex(final Transform t) {
@@ -33,11 +34,19 @@ public final class OperatorVertex extends IRVertex {
     this.transform = t;
   }
 
+  /**
+   * Constructor of OperatorVertex.
+   *
+   * @param that the source object for copying
+   */
+  public OperatorVertex(final OperatorVertex that) {
+    super(that);
+    this.transform = that.transform;
+  }
+
   @Override
   public OperatorVertex getClone() {
-    final OperatorVertex that = new OperatorVertex(this.transform);
-    this.copyExecutionPropertiesTo(that);
-    return that;
+    return new OperatorVertex(this);
   }
 
   /**

--- a/common/src/main/java/edu/snu/nemo/common/ir/vertex/OperatorVertex.java
+++ b/common/src/main/java/edu/snu/nemo/common/ir/vertex/OperatorVertex.java
@@ -26,7 +26,6 @@ public final class OperatorVertex extends IRVertex {
 
   /**
    * Constructor of OperatorVertex.
-   *
    * @param t transform for the OperatorVertex.
    */
   public OperatorVertex(final Transform t) {
@@ -35,12 +34,11 @@ public final class OperatorVertex extends IRVertex {
   }
 
   /**
-   * Constructor of OperatorVertex.
-   *
+   * Copy Constructor of OperatorVertex.
    * @param that the source object for copying
    */
   public OperatorVertex(final OperatorVertex that) {
-    super(that);
+    super();
     this.transform = that.transform;
   }
 

--- a/common/src/main/java/edu/snu/nemo/common/ir/vertex/SourceVertex.java
+++ b/common/src/main/java/edu/snu/nemo/common/ir/vertex/SourceVertex.java
@@ -27,6 +27,21 @@ import java.util.List;
 public abstract class SourceVertex<O> extends IRVertex {
 
   /**
+   * Constructor for SourceVertex.
+   */
+  public SourceVertex() {
+    super();
+  }
+
+  /**
+   * Copy Constructor for SourceVertex.
+   *
+   * @param that the source object for copying
+   */
+  public SourceVertex(final SourceVertex that) {
+    super(that);
+  }
+  /**
    * Gets parallel readables.
    *
    * @param desiredNumOfSplits number of splits desired.

--- a/common/src/main/java/edu/snu/nemo/common/test/EmptyComponents.java
+++ b/common/src/main/java/edu/snu/nemo/common/test/EmptyComponents.java
@@ -113,6 +113,15 @@ public final class EmptyComponents {
       this.name = name;
     }
 
+    /**
+     * Copy Constructor for EmptySourceVertex.
+     *
+     * @param that the source object for copying
+     */
+    public EmptySourceVertex(final EmptySourceVertex that) {
+      this.name = that.name;
+    }
+
     @Override
     public String toString() {
       final StringBuilder sb = new StringBuilder();
@@ -137,7 +146,7 @@ public final class EmptyComponents {
 
     @Override
     public EmptySourceVertex<T> getClone() {
-      return new EmptySourceVertex<>(this.name);
+      return new EmptySourceVertex<>(this);
     }
   }
 

--- a/common/src/main/java/edu/snu/nemo/common/test/EmptyComponents.java
+++ b/common/src/main/java/edu/snu/nemo/common/test/EmptyComponents.java
@@ -119,7 +119,7 @@ public final class EmptyComponents {
      * @param that the source object for copying
      */
     public EmptySourceVertex(final EmptySourceVertex that) {
-      this.name = that.name;
+      this.name = new String(that.name);
     }
 
     @Override

--- a/compiler/frontend/beam/src/main/java/edu/snu/nemo/compiler/frontend/beam/source/BeamBoundedSourceVertex.java
+++ b/compiler/frontend/beam/src/main/java/edu/snu/nemo/compiler/frontend/beam/source/BeamBoundedSourceVertex.java
@@ -41,18 +41,29 @@ public final class BeamBoundedSourceVertex<O> extends SourceVertex<O> {
 
   /**
    * Constructor of BeamBoundedSourceVertex.
+   *
    * @param source BoundedSource to read from.
    */
   public BeamBoundedSourceVertex(final BoundedSource<O> source) {
+    super();
     this.source = source;
     this.sourceDescription = source.toString();
   }
 
+  /**
+   * Constructor of BeamBoundedSourceVertex.
+   *
+   * @param that the source object for copying
+   */
+  public BeamBoundedSourceVertex(final BeamBoundedSourceVertex that) {
+    super(that);
+    this.source = that.source;
+    this.sourceDescription = that.source.toString();
+  }
+
   @Override
   public BeamBoundedSourceVertex getClone() {
-    final BeamBoundedSourceVertex that = new BeamBoundedSourceVertex<>(this.source);
-    this.copyExecutionPropertiesTo(that);
-    return that;
+    return new BeamBoundedSourceVertex(this);
   }
 
   @Override

--- a/compiler/frontend/spark/src/main/java/edu/snu/nemo/compiler/frontend/spark/source/SparkDatasetBoundedSourceVertex.java
+++ b/compiler/frontend/spark/src/main/java/edu/snu/nemo/compiler/frontend/spark/source/SparkDatasetBoundedSourceVertex.java
@@ -41,6 +41,7 @@ public final class SparkDatasetBoundedSourceVertex<T> extends SourceVertex<T> {
    * @param dataset      Dataset to read data from.
    */
   public SparkDatasetBoundedSourceVertex(final SparkSession sparkSession, final Dataset<T> dataset) {
+    super();
     this.readables = new ArrayList<>();
     final RDD rdd = dataset.sparkRDD();
     final Partition[] partitions = rdd.getPartitions();
@@ -54,19 +55,18 @@ public final class SparkDatasetBoundedSourceVertex<T> extends SourceVertex<T> {
   }
 
   /**
-   * Constructor for cloning.
+   * Copy Constructor for SparkDatasetBoundedSourceVertex.
    *
-   * @param readables the list of Readables to set.
+   * @param that the source object for copying
    */
-  private SparkDatasetBoundedSourceVertex(final List<Readable<T>> readables) {
-    this.readables = readables;
+  public SparkDatasetBoundedSourceVertex(final SparkDatasetBoundedSourceVertex that) {
+    super(that);
+    this.readables = that.readables;
   }
 
   @Override
   public SparkDatasetBoundedSourceVertex getClone() {
-    final SparkDatasetBoundedSourceVertex<T> that = new SparkDatasetBoundedSourceVertex<>((this.readables));
-    this.copyExecutionPropertiesTo(that);
-    return that;
+    return new SparkDatasetBoundedSourceVertex(this);
   }
 
   @Override

--- a/compiler/frontend/spark/src/main/java/edu/snu/nemo/compiler/frontend/spark/source/SparkDatasetBoundedSourceVertex.java
+++ b/compiler/frontend/spark/src/main/java/edu/snu/nemo/compiler/frontend/spark/source/SparkDatasetBoundedSourceVertex.java
@@ -59,9 +59,10 @@ public final class SparkDatasetBoundedSourceVertex<T> extends SourceVertex<T> {
    *
    * @param that the source object for copying
    */
-  public SparkDatasetBoundedSourceVertex(final SparkDatasetBoundedSourceVertex that) {
+  public SparkDatasetBoundedSourceVertex(final SparkDatasetBoundedSourceVertex<T> that) {
     super(that);
-    this.readables = that.readables;
+    this.readables = new ArrayList<>();
+    that.readables.forEach(this.readables::add);
   }
 
   @Override

--- a/compiler/frontend/spark/src/main/java/edu/snu/nemo/compiler/frontend/spark/source/SparkTextFileBoundedSourceVertex.java
+++ b/compiler/frontend/spark/src/main/java/edu/snu/nemo/compiler/frontend/spark/source/SparkTextFileBoundedSourceVertex.java
@@ -60,7 +60,8 @@ public final class SparkTextFileBoundedSourceVertex extends SourceVertex<String>
    */
   private SparkTextFileBoundedSourceVertex(final SparkTextFileBoundedSourceVertex that) {
     super(that);
-    this.readables = that.readables;
+    this.readables = new ArrayList<>();
+    that.readables.forEach(this.readables::add);
   }
 
   @Override

--- a/compiler/frontend/spark/src/main/java/edu/snu/nemo/compiler/frontend/spark/source/SparkTextFileBoundedSourceVertex.java
+++ b/compiler/frontend/spark/src/main/java/edu/snu/nemo/compiler/frontend/spark/source/SparkTextFileBoundedSourceVertex.java
@@ -40,6 +40,7 @@ public final class SparkTextFileBoundedSourceVertex extends SourceVertex<String>
   public SparkTextFileBoundedSourceVertex(final SparkContext sparkContext,
                                           final String inputPath,
                                           final int numPartitions) {
+    super();
     this.readables = new ArrayList<>();
     final Partition[] partitions = sparkContext.textFile(inputPath, numPartitions).getPartitions();
     for (int i = 0; i < partitions.length; i++) {
@@ -55,17 +56,16 @@ public final class SparkTextFileBoundedSourceVertex extends SourceVertex<String>
   /**
    * Constructor for cloning.
    *
-   * @param readables the list of Readables to set.
+   * @param that the source object for copying
    */
-  private SparkTextFileBoundedSourceVertex(final List<Readable<String>> readables) {
-    this.readables = readables;
+  private SparkTextFileBoundedSourceVertex(final SparkTextFileBoundedSourceVertex that) {
+    super(that);
+    this.readables = that.readables;
   }
 
   @Override
   public SparkTextFileBoundedSourceVertex getClone() {
-    final SparkTextFileBoundedSourceVertex that = new SparkTextFileBoundedSourceVertex(this.readables);
-    this.copyExecutionPropertiesTo(that);
-    return that;
+    return new SparkTextFileBoundedSourceVertex(this);
   }
 
   @Override


### PR DESCRIPTION
 JIRA: [NEMO-89: Clean up IRVertex#getClone()](https://issues.apache.org/jira/projects/NEMO/issues/NEMO-89)

**Major changes:**
- `getClone()` has been moved into a Interface
 - Copy constructors has been added to the subclasses of the `IRVertex` which does the deep copying of the objects

**Minor changes to note:**
- NA

**Tests for the changes:**
- NA

**Other comments:**
- NA

resolves [NEMO-89](https://issues.apache.org/jira/projects/NEMO/issues/NEMO-89)
