### PR TITLE
[NEMO-197] Close JIRA issues upon closing PRs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,4 +12,4 @@ JIRA: [NEMO-##: TITLE](https://issues.apache.org/jira/projects/NEMO/issues/NEMO-
 **Other comments:**
 - 
 
-resolves [NEMO-##](https://issues.apache.org/jira/projects/NEMO/issues/NEMO-##)
+Closes #GITHUB_PR_NUMBER

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-JIRA: [NEMO-##: TITLE](https://issues.apache.org/jira/projects/NEMO/issues/NEMO-##)
+JIRA: [NEMO-###: TITLE](https://issues.apache.org/jira/projects/NEMO/issues/NEMO-###)
 
 **Major changes:**
 - 


### PR DESCRIPTION
JIRA: [NEMO-197: Automatically close JIRA issues upon closing PRs](https://issues.apache.org/jira/projects/NEMO/issues/NEMO-197)

**Major changes:**
- None

**Minor changes to note:**
- This minor PR updates the final line of the PR template, to automatically close the issue using GitHub.

**Tests for the changes:**
- N/A

**Other comments:**
- N/A

Closes #110 
