### PR TITLE
[NEMO-218] Throws exception while processing non-keyed events in CreateViewTransform

### DIFF
--- a/compiler/frontend/beam/src/main/java/org/apache/nemo/compiler/frontend/beam/transform/CreateViewTransform.java
+++ b/compiler/frontend/beam/src/main/java/org/apache/nemo/compiler/frontend/beam/transform/CreateViewTransform.java
@@ -55,10 +55,8 @@ public final class CreateViewTransform<I, O> implements Transform<I, O> {
   @Override
   public void onData(final I element) {
     // Since CreateViewTransform takes KV(Void, value), this is okay
-    if (element instanceof KV) {
-      final KV<?, ?> kv = (KV<?, ?>) element;
-      multiView.getDataList().add(kv.getValue());
-    }
+    final KV<?, ?> kv = (KV<?, ?>) element; // It will throw a type cast exception if the element is not KV
+    multiView.getDataList().add(kv.getValue());
   }
 
   @Override


### PR DESCRIPTION
JIRA: [NEMO-218: Throws exception while processing non-keyed events in CreateViewTransform](https://issues.apache.org/jira/projects/NEMO/issues/NEMO-218)

**Major changes:**
- remove `if` clause in `CreateViewTransform`.onData()

**Minor changes to note:**
- 

**Tests for the changes:**
- 

**Other comments:**
- 

Closes #121
