### PR TITLE
Make job launcher handle empty user_args

### DIFF
--- a/client/src/main/java/org/apache/nemo/client/JobLauncher.java
+++ b/client/src/main/java/org/apache/nemo/client/JobLauncher.java
@@ -86,6 +86,7 @@ public final class JobLauncher {
   private static CountDownLatch jobDoneLatch;
   private static String serializedDAG;
   private static final List<?> COLLECTED_DATA = new ArrayList<>();
+  private static final String[] EMPTY_USER_ARGS = new String[0];
 
   /**
    * private constructor.
@@ -239,7 +240,8 @@ public final class JobLauncher {
   private static void runUserProgramMain(final Configuration jobConf) throws Exception {
     final Injector injector = TANG.newInjector(jobConf);
     final String className = injector.getNamedInstance(JobConf.UserMainClass.class);
-    final String[] args = injector.getNamedInstance(JobConf.UserMainArguments.class).split(" ");
+    final String userArgsString = injector.getNamedInstance(JobConf.UserMainArguments.class);
+    final String[] args = userArgsString.isEmpty() ? EMPTY_USER_ARGS : userArgsString.split(" ");
     final Class userCode = Class.forName(className);
     final Method method = userCode.getMethod("main", String[].class);
     if (!Modifier.isStatic(method.getModifiers())) {

--- a/examples/spark/src/test/java/org/apache/nemo/examples/spark/SparkScala.java
+++ b/examples/spark/src/test/java/org/apache/nemo/examples/spark/SparkScala.java
@@ -113,7 +113,17 @@ public final class SparkScala {
     JobLauncher.main(builder
       .addJobId(SparkALS.class.getSimpleName() + "_test")
       .addUserMain(SparkALS.class.getCanonicalName())
-      .addUserArgs("100") // TODO #202: Bug with empty string user_args
+      .addUserArgs("100")
+      .addOptimizationPolicy(DefaultPolicy.class.getCanonicalName())
+      .build());
+  }
+
+  @Test(timeout = TIMEOUT)
+  public void testALSEmptyUserArgs() throws Exception {
+    JobLauncher.main(builder
+      .addJobId(SparkALS.class.getSimpleName() + "_test")
+      .addUserMain(SparkALS.class.getCanonicalName())
+      .addUserArgs("")
       .addOptimizationPolicy(DefaultPolicy.class.getCanonicalName())
       .build());
   }


### PR DESCRIPTION
JIRA: [NEMO-202: Bug with empty string user_args](https://issues.apache.org/jira/projects/NEMO/issues/NEMO-202)

**Major changes:**
- Make JobLauncher handle an empty string ("") for user_args
- When an empty string is given, JobLauncher passes an empty array (String[0]) to the application.
 
**Minor changes to note:**
- N/A

**Tests for the changes:**
- Added SparkScala#testALSEmptyUserArgs.

**Other comments:**
- N/A

Closes #GITHUB_PR_NUMBER
