### PR TITLE
[NEMO-266] Throws NoSuchElementException in Readeable.readCurrent

### DIFF
--- a/common/src/main/java/org/apache/nemo/common/ir/BoundedIteratorReadable.java
+++ b/common/src/main/java/org/apache/nemo/common/ir/BoundedIteratorReadable.java
@@ -48,11 +48,6 @@ public abstract class BoundedIteratorReadable<O> implements Readable<O> {
   }
 
   @Override
-  public final void advance() {
-    // do nothing
-  }
-
-  @Override
   public final boolean isFinished() {
     return !iterator.hasNext();
   }

--- a/common/src/main/java/org/apache/nemo/common/ir/Readable.java
+++ b/common/src/main/java/org/apache/nemo/common/ir/Readable.java
@@ -45,11 +45,6 @@ public interface Readable<O> extends Serializable {
   O readCurrent() throws NoSuchElementException;
 
   /**
-   * Advance current data point.
-   */
-  void advance() throws IOException;
-
-  /**
    * Read watermark.
    * @return watermark
    */

--- a/common/src/main/java/org/apache/nemo/common/ir/vertex/CachedSourceVertex.java
+++ b/common/src/main/java/org/apache/nemo/common/ir/vertex/CachedSourceVertex.java
@@ -101,12 +101,6 @@ public final class CachedSourceVertex<T> extends SourceVertex<T> {
     }
 
     @Override
-    public void advance() throws IOException {
-      throw new UnsupportedOperationException(
-        "CachedSourceVertex should not be used");
-    }
-
-    @Override
     public long readWatermark() {
       throw new UnsupportedOperationException(
         "CachedSourceVertex should not be used");

--- a/common/src/main/java/org/apache/nemo/common/test/EmptyComponents.java
+++ b/common/src/main/java/org/apache/nemo/common/test/EmptyComponents.java
@@ -247,10 +247,6 @@ public final class EmptyComponents {
     }
 
     @Override
-    public void advance() {
-    }
-
-    @Override
     public long readWatermark() {
       return 0;
     }

--- a/runtime/executor/src/main/java/org/apache/nemo/runtime/executor/task/SourceVertexDataFetcher.java
+++ b/runtime/executor/src/main/java/org/apache/nemo/runtime/executor/task/SourceVertexDataFetcher.java
@@ -105,7 +105,6 @@ class SourceVertexDataFetcher extends DataFetcher {
 
     // Data
     final Object element = readable.readCurrent();
-    readable.advance();
     return element;
   }
 }

--- a/runtime/executor/src/test/java/org/apache/nemo/runtime/executor/task/TaskExecutorTest.java
+++ b/runtime/executor/src/test/java/org/apache/nemo/runtime/executor/task/TaskExecutorTest.java
@@ -694,12 +694,9 @@ public final class TaskExecutorTest {
       if (pointer == middle && numEmittedWatermarks < expectedNumWatermarks) {
         throw new NoSuchElementException();
       }
-      return elements.get(pointer);
-    }
-
-    @Override
-    public void advance() throws IOException {
+      final Object element = elements.get(pointer);
       pointer += 1;
+      return element;
     }
 
     @Override


### PR DESCRIPTION
JIRA: [NEMO-266: Throws NoSuchElementException in Readeable.readCurrent](https://issues.apache.org/jira/projects/NEMO/issues/NEMO-266)

**Major changes:**
- remove `advance` method in `Readable` and throws `NoSuchElementException` in `BeamUnboundedSourceVertex.readCurrent()`.
