### PR TITLE
[NEMO-275] Eager Garbage Collection for GroupByKey

### DIFF
--- a/compiler/frontend/beam/src/main/java/org/apache/nemo/compiler/frontend/beam/transform/GroupByKeyTransform.java
+++ b/compiler/frontend/beam/src/main/java/org/apache/nemo/compiler/frontend/beam/transform/GroupByKeyTransform.java
@@ -61,10 +61,12 @@ public final class GroupByKeyTransform<I> extends NoWatermarkEmitTransform<I, Wi
     if (keyToValues.isEmpty()) {
       LOG.warn("Beam GroupByKeyTransform received no data!");
     } else {
-      keyToValues.entrySet().stream().map(entry ->
-        WindowedValue.valueInGlobalWindow(KV.of(entry.getKey(), entry.getValue())))
-        .forEach(outputCollector::emit);
-      keyToValues.clear();
+      final Iterator<Map.Entry<Object, List>> iterator = keyToValues.entrySet().iterator();
+      while (iterator.hasNext()) {
+        final Map.Entry<Object, List> entry = iterator.next();
+        outputCollector.emit(WindowedValue.valueInGlobalWindow(KV.of(entry.getKey(), entry.getValue())));
+        iterator.remove();
+      }
     }
   }
 


### PR DESCRIPTION
JIRA: [NEMO-275: Eager Garbage Collection for GroupByKey](https://issues.apache.org/jira/projects/NEMO/issues/NEMO-275)

**Major changes:**
- Instead of iterating over the accumulated elements and then clearing out all the elements at once, remove the elements while iterating