### PR TITLE
[NEMO-303] Use Surefire 3.0.0-M1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@ under the License.
         <!-- Tests -->
         <mockito.version>2.13.0</mockito.version>
         <powermock.version>2.0.0-beta.5</powermock.version>
+        <surefire.version>3.0.0-M1</surefire.version>
         <junit.version>4.12</junit.version>
     </properties>
 
@@ -156,23 +157,28 @@ under the License.
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>sonar-maven-plugin</artifactId>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${surefire.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <version>${surefire.version}</version>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>integration-test</goal>
+                                <goal>verify</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
             </plugins>
         </pluginManagement>
 
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.20.1</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>integration-test</goal>
-                            <goal>verify</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>


### PR DESCRIPTION
JIRA: [NEMO-303: Use Surefire 3.0.0-M1](https://issues.apache.org/jira/projects/NEMO/issues/NEMO-303)

**Minor changes to note:**
- POM: Use maven-surefire-plugin 3.0.0-M1 and maven-failsafe-plugin 3.0.0-M1

**Notes**
- See SUREFIRE-1588 for the relevant bug report at the ASF Jira system