### PR TITLE
[NEMO-318] Make nemo.common.Cloneable extend java.lang.Cloneable

### DIFF
--- a/common/src/main/java/org/apache/nemo/common/Cloneable.java
+++ b/common/src/main/java/org/apache/nemo/common/Cloneable.java
@@ -29,7 +29,7 @@ package org.apache.nemo.common;
  *
  * @param <T> the type of objects that this class can clone
  */
-public interface Cloneable<T extends Cloneable<T>> {
+public interface Cloneable<T extends java.lang.Cloneable> {
 
   /**
    * Creates and returns a copy of this object.


### PR DESCRIPTION
JIRA: [NEMO-318: Make org.apache.nemo.common.Cloneable inherit java.lang.Cloneable](https://issues.apache.org/jira/projects/NEMO/issues/NEMO-318)

**Minor changes to note:**
- Made org.apache.nemo.common.Cloneable inherit java.lang.Cloneable, not itself