### PR TITLE
[NEMO-319] Fix path to beam resources in examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,11 +133,11 @@ Nemo Compiler and Engine can store JSON representation of intermediate DAGs.
 ```bash
 ./bin/run_beam.sh \
 	-job_id als \
-	-executor_json `pwd`/examples/resources/beam_test_executor_resources.json \
+	-executor_json `pwd`/examples/resources/executors/beam_test_executor_resources.json \
   	-user_main org.apache.nemo.examples.beam.AlternatingLeastSquare \
   	-optimization_policy org.apache.nemo.compiler.optimizer.policy.TransientResourcePolicy \
   	-dag_dir "./dag/als" \
-  	-user_args "`pwd`/examples/resources/test_input_als 10 3"
+  	-user_args "`pwd`/examples/resources/inputs/test_input_als 10 3"
 ```
 
 ## Speeding up builds 


### PR DESCRIPTION
JIRA: [NEMO-319] Fix path to beam resources in examples in README (https://issues.apache.org/jira/projects/NEMO/issues/NEMO-319)

Files in `examples/beam/resources` were moved in #146 but the commands in the README were not updated.