### PR TITLE
[NEMO-292] (WIP) Run Beam ValidatesRunner tests

### DIFF
--- a/compiler/frontend/beam/spectests/pom.xml
+++ b/compiler/frontend/beam/spectests/pom.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.nemo</groupId>
+        <artifactId>nemo-compiler</artifactId>
+        <version>0.1-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+
+    <artifactId>nemo-compiler-frontend-beam-spectests</artifactId>
+    <name>Nemo Compiler Frontend: Beam spec tests</name>
+
+    <dependencies>
+	<dependency>
+            <groupId>org.apache.nemo</groupId>
+            <artifactId>nemo-compiler-frontend-beam-spectestsbundle</artifactId>
+	    <version>${project.version}</version>
+	    <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+     <build>
+       <plugins>
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>${surefire.version}</version>
+            <executions>
+              <execution>
+                <id>validates-runner-tests</id>
+                <phase>integration-test</phase>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+		<configuration>
+                  <groups>org.apache.beam.sdk.testing.ValidatesRunner</groups>
+                  <excludedGroups>
+                    org.apache.beam.sdk.testing.UsesStatefulParDo,
+                    org.apache.beam.sdk.testing.UsesTimersInParDo,
+                    org.apache.beam.sdk.testing.UsesAttemptedMetrics,
+                    org.apache.beam.sdk.testing.UsesCommittedMetrics,
+                    org.apache.beam.sdk.testing.UsesTestStream,
+                    org.apache.beam.sdk.testing.UsesCustomWindowMerging
+                  </excludedGroups>
+                  <parallel>none</parallel>
+                  <failIfNoTests>true</failIfNoTests>
+                  <dependenciesToScan>
+                    <dependency>org.apache.nemo:nemo-compiler-frontend-beam-spectestsbundle</dependency>
+                  </dependenciesToScan>
+                  <systemPropertyVariables>
+                    <beamTestPipelineOptions>
+                      [
+                      "--runner=NemoRunner"
+                      ]
+                    </beamTestPipelineOptions>
+                  </systemPropertyVariables>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+</project>

--- a/compiler/frontend/beam/spectestsbundle/pom.xml
+++ b/compiler/frontend/beam/spectestsbundle/pom.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.nemo</groupId>
+        <artifactId>nemo-compiler</artifactId>
+        <version>0.1-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+
+    <artifactId>nemo-compiler-frontend-beam-spectestsbundle</artifactId>
+    <name>Nemo Compiler Frontend: Beam spec tests bundle</name>
+    <packaging>jar</packaging>
+
+    <dependencies>
+	<dependency>
+            <groupId>org.apache.nemo</groupId>
+            <artifactId>nemo-compiler-frontend-beam</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.beam</groupId>
+            <artifactId>beam-sdks-java-core</artifactId>
+	    <version>${beam.version}</version>
+	    <classifier>tests</classifier>
+        </dependency>
+    </dependencies>
+
+     <build>
+       <plugins>
+	       <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <transformers>
+                                <!-- Required for using beam-hadoop: See https://stackoverflow.com/questions/44365545
+                                -->
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer" />
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+      </build>
+</project>

--- a/compiler/pom.xml
+++ b/compiler/pom.xml
@@ -47,6 +47,8 @@ under the License.
   <modules>
     <module>backend</module>
     <module>frontend/beam</module>
+    <module>frontend/beam/spectestsbundle</module>
+    <module>frontend/beam/spectests</module>
     <module>frontend/spark</module>
     <module>optimizer</module>
     <module>test</module>


### PR DESCRIPTION
Opening this for early feedback. I spent a little while trying to get this to run, but did not finish it. I hope that some member of the Nemo community can easily point to my error.

In this draft:

 - `compiler/frontend/beam/spectestsbundle` is an über jar with everything needed to run the tests
 - `compiler/frontend/beam/spectests` is the maven surefire config to run the tests

I still get `ClassNotFound: CoderRegistry` in every test case, so the deps & bundling & distribution of the code is clearly still not right.

Previously, I tried doing this inline in `compiler/frontend/beam/pom.xml`. I got the same error and thought it might be something to do with how the jars are used to execute the tests, so (like most distributed big data systems) I built more logic to create an über jar. The simpler version is here: https://github.com/kennknowles/incubator-nemo/tree/first-try-spectests