### PR TITLE
[NEMO-327] Fix skew handling for multi shuffle edge receiver

### DIFF
--- a/common/src/main/java/org/apache/nemo/common/dag/DAGBuilder.java
+++ b/common/src/main/java/org/apache/nemo/common/dag/DAGBuilder.java
@@ -259,8 +259,7 @@ public final class DAGBuilder<V extends Vertex, E extends Edge<V>> implements Se
   private void executionPropertyCheck() {
     // DataSizeMetricCollection is not compatible with Push (All data have to be stored before the data collection)
     vertices.forEach(v -> incomingEdges.get(v).stream().filter(e -> e instanceof IREdge).map(e -> (IREdge) e)
-        .filter(e -> Optional.of(MetricCollectionProperty.Value.DataSkewRuntimePass)
-            .equals(e.getPropertyValue(MetricCollectionProperty.class)))
+        .filter(e -> e.getPropertyValue(MetricCollectionProperty.class).isPresent())
         .filter(e -> DataFlowProperty.Value.Push.equals(e.getPropertyValue(DataFlowProperty.class).get()))
         .forEach(e -> {
           throw new CompileTimeOptimizationException("DAG execution property check: "

--- a/common/src/main/java/org/apache/nemo/common/dag/DAGBuilder.java
+++ b/common/src/main/java/org/apache/nemo/common/dag/DAGBuilder.java
@@ -24,6 +24,7 @@ import org.apache.nemo.common.ir.edge.executionproperty.DataFlowProperty;
 import org.apache.nemo.common.ir.edge.executionproperty.MetricCollectionProperty;
 import org.apache.nemo.common.ir.vertex.*;
 import org.apache.nemo.common.exception.IllegalVertexOperationException;
+import org.apache.nemo.common.ir.vertex.transform.AggregateMetricTransform;
 
 import java.io.Serializable;
 import java.util.*;
@@ -260,6 +261,8 @@ public final class DAGBuilder<V extends Vertex, E extends Edge<V>> implements Se
     // DataSizeMetricCollection is not compatible with Push (All data have to be stored before the data collection)
     vertices.forEach(v -> incomingEdges.get(v).stream().filter(e -> e instanceof IREdge).map(e -> (IREdge) e)
         .filter(e -> e.getPropertyValue(MetricCollectionProperty.class).isPresent())
+        .filter(e -> !(e.getDst() instanceof OperatorVertex
+          && ((OperatorVertex) e.getDst()).getTransform() instanceof AggregateMetricTransform))
         .filter(e -> DataFlowProperty.Value.Push.equals(e.getPropertyValue(DataFlowProperty.class).get()))
         .forEach(e -> {
           throw new CompileTimeOptimizationException("DAG execution property check: "

--- a/common/src/main/java/org/apache/nemo/common/ir/edge/executionproperty/MetricCollectionProperty.java
+++ b/common/src/main/java/org/apache/nemo/common/ir/edge/executionproperty/MetricCollectionProperty.java
@@ -23,12 +23,12 @@ import org.apache.nemo.common.ir.executionproperty.EdgeExecutionProperty;
 /**
  * MetricCollection ExecutionProperty that indicates the edge of which data metric will be collected.
  */
-public final class MetricCollectionProperty extends EdgeExecutionProperty<MetricCollectionProperty.Value> {
+public final class MetricCollectionProperty extends EdgeExecutionProperty<Integer> {
   /**
    * Constructor.
    * @param value value of the execution property.
    */
-  private MetricCollectionProperty(final Value value) {
+  private MetricCollectionProperty(final Integer value) {
     super(value);
   }
 
@@ -37,14 +37,7 @@ public final class MetricCollectionProperty extends EdgeExecutionProperty<Metric
    * @param value value of the new execution property.
    * @return the newly created execution property.
    */
-  public static MetricCollectionProperty of(final Value value) {
+  public static MetricCollectionProperty of(final Integer value) {
     return new MetricCollectionProperty(value);
-  }
-
-  /**
-   * Possible values of MetricCollection ExecutionProperty.
-   */
-  public enum Value {
-    DataSkewRuntimePass
   }
 }

--- a/examples/beam/src/test/java/org/apache/nemo/examples/beam/NetworkTraceAnalysisITCase.java
+++ b/examples/beam/src/test/java/org/apache/nemo/examples/beam/NetworkTraceAnalysisITCase.java
@@ -95,7 +95,7 @@ public final class NetworkTraceAnalysisITCase {
   @Test (timeout = ExampleTestArgs.TIMEOUT)
   public void testDataSkew() throws Exception {
     JobLauncher.main(builder
-      .addJobId(NetworkTraceAnalysisITCase.class.getSimpleName())
+      .addJobId(NetworkTraceAnalysisITCase.class.getSimpleName() + "_skew")
       .addOptimizationPolicy(DataSkewPolicyParallelismFive.class.getCanonicalName())
       .build());
   }

--- a/examples/beam/src/test/java/org/apache/nemo/examples/beam/NetworkTraceAnalysisITCase.java
+++ b/examples/beam/src/test/java/org/apache/nemo/examples/beam/NetworkTraceAnalysisITCase.java
@@ -22,6 +22,7 @@ import org.apache.nemo.client.JobLauncher;
 import org.apache.nemo.common.test.ArgBuilder;
 import org.apache.nemo.common.test.ExampleTestArgs;
 import org.apache.nemo.common.test.ExampleTestUtil;
+import org.apache.nemo.examples.beam.policy.DataSkewPolicyParallelismFive;
 import org.apache.nemo.examples.beam.policy.DefaultPolicyParallelismFive;
 import org.apache.nemo.examples.beam.policy.TransientResourcePolicyParallelismFive;
 import org.apache.nemo.examples.beam.policy.LargeShufflePolicyParallelismFive;
@@ -85,5 +86,17 @@ public final class NetworkTraceAnalysisITCase {
         .addJobId(NetworkTraceAnalysisITCase.class.getSimpleName() + "_transient")
         .addOptimizationPolicy(TransientResourcePolicyParallelismFive.class.getCanonicalName())
         .build());
+  }
+
+  /**
+   * Testing data skew dynamic optimization.
+   * @throws Exception exception on the way.
+   */
+  @Test (timeout = ExampleTestArgs.TIMEOUT)
+  public void testDataSkew() throws Exception {
+    JobLauncher.main(builder
+      .addJobId(NetworkTraceAnalysisITCase.class.getSimpleName())
+      .addOptimizationPolicy(DataSkewPolicyParallelismFive.class.getCanonicalName())
+      .build());
   }
 }

--- a/runtime/common/src/main/java/org/apache/nemo/runtime/common/eventhandler/DynamicOptimizationEvent.java
+++ b/runtime/common/src/main/java/org/apache/nemo/runtime/common/eventhandler/DynamicOptimizationEvent.java
@@ -22,6 +22,8 @@ import org.apache.nemo.common.eventhandler.RuntimeEvent;
 import org.apache.nemo.runtime.common.plan.PhysicalPlan;
 import org.apache.nemo.runtime.common.plan.StageEdge;
 
+import java.util.Set;
+
 /**
  * An event for triggering dynamic optimization.
  */
@@ -30,24 +32,27 @@ public final class DynamicOptimizationEvent implements RuntimeEvent {
   private final Object dynOptData;
   private final String taskId;
   private final String executorId;
-  private final StageEdge targetEdge;
+  private final Set<StageEdge> targetEdges;
 
   /**
    * Default constructor.
-   * @param physicalPlan physical plan to be optimized.
-   * @param taskId id of the task which triggered the dynamic optimization.
-   * @param executorId the id of executor which executes {@code taskId}
+   *
+   * @param physicalPlan the physical plan to be optimized.
+   * @param dynOptData   the metric data.
+   * @param taskId       the ID of the task which triggered the dynamic optimization.
+   * @param executorId   the ID of executor which executes {@code taskId}
+   * @param targetEdges  the target edges.
    */
   public DynamicOptimizationEvent(final PhysicalPlan physicalPlan,
                                   final Object dynOptData,
                                   final String taskId,
                                   final String executorId,
-                                  final StageEdge targetEdge) {
+                                  final Set<StageEdge> targetEdges) {
     this.physicalPlan = physicalPlan;
     this.taskId = taskId;
     this.dynOptData = dynOptData;
     this.executorId = executorId;
-    this.targetEdge = targetEdge;
+    this.targetEdges = targetEdges;
   }
 
   /**
@@ -75,7 +80,7 @@ public final class DynamicOptimizationEvent implements RuntimeEvent {
     return this.dynOptData;
   }
 
-  public StageEdge getTargetEdge() {
-    return this.targetEdge;
+  public Set<StageEdge> getTargetEdges() {
+    return this.targetEdges;
   }
 }

--- a/runtime/common/src/main/java/org/apache/nemo/runtime/common/eventhandler/DynamicOptimizationEventHandler.java
+++ b/runtime/common/src/main/java/org/apache/nemo/runtime/common/eventhandler/DynamicOptimizationEventHandler.java
@@ -26,6 +26,7 @@ import org.apache.nemo.runtime.common.plan.StageEdge;
 import org.apache.reef.wake.impl.PubSubEventHandler;
 
 import javax.inject.Inject;
+import java.util.Set;
 
 /**
  * Class for handling event to perform dynamic optimization.
@@ -51,9 +52,9 @@ public final class DynamicOptimizationEventHandler implements RuntimeEventHandle
   public void onNext(final DynamicOptimizationEvent dynamicOptimizationEvent) {
     final PhysicalPlan physicalPlan = dynamicOptimizationEvent.getPhysicalPlan();
     final Object dynOptData = dynamicOptimizationEvent.getDynOptData();
-    final StageEdge targetEdge = dynamicOptimizationEvent.getTargetEdge();
+    final Set<StageEdge> targetEdges = dynamicOptimizationEvent.getTargetEdges();
 
-    final PhysicalPlan newPlan = RunTimeOptimizer.dynamicOptimization(physicalPlan, dynOptData, targetEdge);
+    final PhysicalPlan newPlan = RunTimeOptimizer.dynamicOptimization(physicalPlan, dynOptData, targetEdges);
 
     pubSubEventHandler.onNext(new UpdatePhysicalPlanEvent(newPlan, dynamicOptimizationEvent.getTaskId(),
         dynamicOptimizationEvent.getExecutorId()));

--- a/runtime/common/src/main/java/org/apache/nemo/runtime/common/optimizer/RunTimeOptimizer.java
+++ b/runtime/common/src/main/java/org/apache/nemo/runtime/common/optimizer/RunTimeOptimizer.java
@@ -38,18 +38,20 @@ public final class RunTimeOptimizer {
   /**
    * Dynamic optimization method to process the dag with an appropriate pass, decided by the stats.
    *
-   * @param originalPlan original physical execution plan.
+   * @param originalPlan the original physical execution plan.
+   * @param dynOptData   the data metric.
+   * @param targetEdges  the target edges.
    * @return the newly updated optimized physical plan.
    */
   public static synchronized PhysicalPlan dynamicOptimization(
           final PhysicalPlan originalPlan,
           final Object dynOptData,
-          final StageEdge targetEdge) {
+          final Set<StageEdge> targetEdges) {
     // Data for dynamic optimization used in DataSkewRuntimePass
     // is a map of <hash value, partition size>.
     final PhysicalPlan physicalPlan =
       new DataSkewRuntimePass()
-        .apply(originalPlan, Pair.of(targetEdge, (Map<Object, Long>) dynOptData));
+        .apply(originalPlan, Pair.of(targetEdges, (Map<Object, Long>) dynOptData));
     return physicalPlan;
   }
 }

--- a/runtime/common/src/main/java/org/apache/nemo/runtime/common/optimizer/pass/runtime/DataSkewRuntimePass.java
+++ b/runtime/common/src/main/java/org/apache/nemo/runtime/common/optimizer/pass/runtime/DataSkewRuntimePass.java
@@ -45,7 +45,7 @@ import java.util.stream.Collectors;
  * this RuntimePass identifies a number of keys with big partition sizes(skewed key)
  * and evenly redistributes data via overwriting incoming edges of destination tasks.
  */
-public final class DataSkewRuntimePass extends RuntimePass<Pair<StageEdge, Map<Object, Long>>> {
+public final class DataSkewRuntimePass extends RuntimePass<Pair<Set<StageEdge>, Map<Object, Long>>> {
   private static final Logger LOG = LoggerFactory.getLogger(DataSkewRuntimePass.class.getName());
   private static final int DEFAULT_NUM_SKEWED_KEYS = 1;
   /*
@@ -87,8 +87,8 @@ public final class DataSkewRuntimePass extends RuntimePass<Pair<StageEdge, Map<O
 
   @Override
   public PhysicalPlan apply(final PhysicalPlan originalPlan,
-                            final Pair<StageEdge, Map<Object, Long>> metricData) {
-    final StageEdge targetEdge = metricData.left();
+                            final Pair<Set<StageEdge>, Map<Object, Long>> metricData) {
+    final Set<StageEdge> targetEdges = metricData.left();
     // Get number of evaluators of the next stage (number of blocks).
     final Integer dstParallelism = targetEdge.getDst().getPropertyValue(ParallelismProperty.class).
         orElseThrow(() -> new RuntimeException("No parallelism on a vertex"));

--- a/runtime/common/src/main/java/org/apache/nemo/runtime/common/optimizer/pass/runtime/DataSkewRuntimePass.java
+++ b/runtime/common/src/main/java/org/apache/nemo/runtime/common/optimizer/pass/runtime/DataSkewRuntimePass.java
@@ -57,7 +57,7 @@ public final class DataSkewRuntimePass extends RuntimePass<Pair<Set<StageEdge>, 
    * The reason why we do not divide the output into a fixed number is that the fixed number can be smaller than
    * the destination task parallelism.
    */
-  public static final int HASH_RANGE_MULTIPLIER = 10;
+  public static final int HASH_RANGE_MULTIPLIER = 5;
 
   private final Set<Class<? extends RuntimeEventHandler>> eventHandlers;
   // Skewed keys denote for top n keys in terms of partition size.
@@ -232,6 +232,7 @@ public final class DataSkewRuntimePass extends RuntimePass<Pair<Set<StageEdge>, 
             currentAccumulatedSize - prevAccumulatedSize);
       }
     }
+
     return keyRanges;
   }
 }

--- a/runtime/common/src/main/java/org/apache/nemo/runtime/common/partitioner/DataSkewHashPartitioner.java
+++ b/runtime/common/src/main/java/org/apache/nemo/runtime/common/partitioner/DataSkewHashPartitioner.java
@@ -23,8 +23,6 @@ import org.apache.nemo.runtime.common.optimizer.pass.runtime.DataSkewRuntimePass
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.math.BigInteger;
-
 /**
  * An implementation of {@link Partitioner} which hashes output data from a source task appropriate to detect data skew.
  * It hashes data finer than {@link HashPartitioner}.
@@ -38,7 +36,6 @@ import java.math.BigInteger;
 public final class DataSkewHashPartitioner implements Partitioner<Integer> {
   private static final Logger LOG = LoggerFactory.getLogger(DataSkewHashPartitioner.class.getName());
   private final KeyExtractor keyExtractor;
-  private final BigInteger hashRangeBase;
   private final int hashRange;
 
   /**
@@ -51,10 +48,7 @@ public final class DataSkewHashPartitioner implements Partitioner<Integer> {
                                  final KeyExtractor keyExtractor) {
     this.keyExtractor = keyExtractor;
     // For this hash range, please check the description of HashRangeMultiplier in JobConf.
-    // For actual hash range to use, we calculate a prime number right next to the desired hash range.
-    this.hashRangeBase = new BigInteger(String.valueOf(dstParallelism * DataSkewRuntimePass.HASH_RANGE_MULTIPLIER));
-    this.hashRange = hashRangeBase.nextProbablePrime().intValue();
-    LOG.info("hashRangeBase {} resulting hashRange {}", hashRangeBase, hashRange);
+    this.hashRange = dstParallelism * DataSkewRuntimePass.HASH_RANGE_MULTIPLIER;
   }
 
   @Override

--- a/runtime/master/src/main/java/org/apache/nemo/runtime/master/scheduler/BatchScheduler.java
+++ b/runtime/master/src/main/java/org/apache/nemo/runtime/master/scheduler/BatchScheduler.java
@@ -24,6 +24,7 @@ import org.apache.nemo.common.dag.DAG;
 import org.apache.nemo.common.eventhandler.PubSubEventHandlerWrapper;
 import org.apache.nemo.common.ir.Readable;
 import org.apache.nemo.common.ir.edge.executionproperty.MetricCollectionProperty;
+import org.apache.nemo.common.ir.vertex.OperatorVertex;
 import org.apache.nemo.common.ir.vertex.executionproperty.ClonedSchedulingProperty;
 import org.apache.nemo.common.ir.vertex.executionproperty.IgnoreSchedulingTempDataReceiverProperty;
 import org.apache.nemo.runtime.common.RuntimeIdManager;
@@ -422,42 +423,51 @@ public final class BatchScheduler implements Scheduler {
   }
 
   /**
-   * Get the target edge of dynamic optimization.
-   * The edge is annotated with {@link MetricCollectionProperty}, which is an outgoing edge of
-   * a parent of the stage put on hold.
+   * Get the target edges of dynamic optimization.
+   * The edges are annotated with {@link MetricCollectionProperty}, which are outgoing edges of
+   * parents of the stage put on hold.
    *
    * See {@link org.apache.nemo.compiler.optimizer.pass.compiletime.reshaping.SkewReshapingPass}
-   * for setting the target edge of dynamic optimization.
+   * for setting the target edges of dynamic optimization.
    *
    * @param taskId the task ID that sent stage-level aggregated metric for dynamic optimization.
-   * @return the edge to optimize.
+   * @return the edges to optimize.
    */
-  private StageEdge getEdgeToOptimize(final String taskId) {
+  private Set<StageEdge> getEdgesToOptimize(final String taskId) {
+    final DAG<Stage, StageEdge> stageDag = planStateManager.getPhysicalPlan().getStageDAG();
+
     // Get a stage including the given task
-    final Stage stagePutOnHold = planStateManager.getPhysicalPlan().getStageDAG().getVertices().stream()
+    final Stage stagePutOnHold = stageDag.getVertices().stream()
       .filter(stage -> stage.getId().equals(RuntimeIdManager.getStageIdFromTaskId(taskId)))
       .findFirst()
       .orElseThrow(() -> new RuntimeException());
 
     // Stage put on hold, i.e. stage with vertex containing AggregateMetricTransform
     // should have a parent stage whose outgoing edges contain the target edge of dynamic optimization.
-    final List<Stage> parentStages = planStateManager.getPhysicalPlan().getStageDAG()
-      .getParents(stagePutOnHold.getId());
+    final List<StageEdge> edgesToStagePutOnHold = stageDag.getIncomingEdgesOf(stagePutOnHold);
+    if (edgesToStagePutOnHold.isEmpty()) {
+      throw new RuntimeException("No edges toward specified put on hold stage");
+    }
+    final int metricCollectionId = edgesToStagePutOnHold.get(0).getPropertyValue(MetricCollectionProperty.class)
+      .orElseThrow(() -> new RuntimeException("No metric collection property value for this put on hold stage"));
 
-    if (parentStages.size() > 1) {
-      throw new RuntimeException("Error in setting target edge of dynamic optimization!");
+    final Set<StageEdge> targetEdges = new HashSet<>();
+
+    // Get edges with identical MetricCollectionProperty (except the put on hold stage)
+    for (final Stage stage : stageDag.getVertices()) {
+      final Set<StageEdge> targetEdgesFound = stageDag.getOutgoingEdgesOf(stage).stream()
+        .filter(candidateEdge -> {
+          final Optional<Integer> candidateMCId =
+            candidateEdge.getPropertyValue(MetricCollectionProperty.class);
+          return candidateMCId.isPresent() && candidateMCId.get().equals(metricCollectionId)
+            && !edgesToStagePutOnHold.contains(candidateEdge);
+        })
+        .collect(Collectors.toSet());
+      targetEdges.addAll(targetEdgesFound);
     }
 
-    // Get outgoing edges of that stage with MetricCollectionProperty
-    final List<StageEdge> stageEdges = planStateManager.getPhysicalPlan().getStageDAG()
-      .getOutgoingEdgesOf(parentStages.get(0));
-    for (StageEdge edge : stageEdges) {
-      if (edge.getExecutionProperties().containsKey(MetricCollectionProperty.class)) {
-        return edge;
-      }
-    }
-
-    return null;
+    LOG.info("Target edges to optimize: {}", targetEdges.stream().map(edge -> edge.getId()).collect(Collectors.toSet()));
+    return targetEdges;
   }
 
   /**
@@ -478,8 +488,8 @@ public final class BatchScheduler implements Scheduler {
     final boolean stageComplete =
       planStateManager.getStageState(stageIdForTaskUponCompletion).equals(StageState.State.COMPLETE);
 
-    final StageEdge targetEdge = getEdgeToOptimize(taskId);
-    if (targetEdge == null) {
+    final Set<StageEdge> targetEdges = getEdgesToOptimize(taskId);
+    if (targetEdges.isEmpty()) {
       throw new RuntimeException("No edges specified for data skew optimization");
     }
 
@@ -489,7 +499,7 @@ public final class BatchScheduler implements Scheduler {
         .findFirst().orElseThrow(() -> new RuntimeException("DataSkewDynOptDataHandler is not registered!"));
       pubSubEventHandlerWrapper.getPubSubEventHandler()
         .onNext(new DynamicOptimizationEvent(planStateManager.getPhysicalPlan(), dynOptDataHandler.getDynOptData(),
-          taskId, executorId, targetEdge));
+          taskId, executorId, targetEdges));
     }
   }
 

--- a/runtime/master/src/main/java/org/apache/nemo/runtime/master/scheduler/BatchScheduler.java
+++ b/runtime/master/src/main/java/org/apache/nemo/runtime/master/scheduler/BatchScheduler.java
@@ -24,7 +24,6 @@ import org.apache.nemo.common.dag.DAG;
 import org.apache.nemo.common.eventhandler.PubSubEventHandlerWrapper;
 import org.apache.nemo.common.ir.Readable;
 import org.apache.nemo.common.ir.edge.executionproperty.MetricCollectionProperty;
-import org.apache.nemo.common.ir.vertex.OperatorVertex;
 import org.apache.nemo.common.ir.vertex.executionproperty.ClonedSchedulingProperty;
 import org.apache.nemo.common.ir.vertex.executionproperty.IgnoreSchedulingTempDataReceiverProperty;
 import org.apache.nemo.runtime.common.RuntimeIdManager;
@@ -466,7 +465,8 @@ public final class BatchScheduler implements Scheduler {
       targetEdges.addAll(targetEdgesFound);
     }
 
-    LOG.info("Target edges to optimize: {}", targetEdges.stream().map(edge -> edge.getId()).collect(Collectors.toSet()));
+    LOG.info("Target edges to optimize: {}",
+      targetEdges.stream().map(edge -> edge.getId()).collect(Collectors.toSet()));
     return targetEdges;
   }
 


### PR DESCRIPTION
JIRA: [NEMO-327: Fix skew handling for multi shuffle edge receive](https://issues.apache.org/jira/projects/NEMO/issues/NEMO-327)

**Major changes:**
- For the case that a vertex receives multiple shuffle edges, makes `DataSkewPolicy` collect metric data for the shuffle edges in a single metric aggregation vertex and optimize the edges at once.

**Minor changes to note:**
- Makes runtime pass receive multiple target edges.

**Tests for the changes:**
- Adds an integration test with the data skew policy for `NetworkTraceAnalysis` that has a join.

**Other comments:**
- N/A.

Closes #189
