### PR TITLE
[NEMO-357] Fix broken link on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Nemo
 
 [![Build Status](https://travis-ci.org/apache/incubator-nemo.svg?branch=master)](https://travis-ci.org/apache/incubator-nemo)
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=apache_incubator-nemo&metric=alert_status)](https://sonarcloud.io/dashboard?id=apache_incubator-nemo)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=org.apache.nemo%3Anemo-project&metric=alert_status)](https://sonarcloud.io/dashboard?id=org.apache.nemo%3Anemo-project)
 
 A Data Processing System for Flexible Employment With Different Deployment Characteristics.
 


### PR DESCRIPTION
JIRA: [NEMO-357: Fix broken link on README](https://issues.apache.org/jira/projects/NEMO/issues/NEMO-357)

**Major changes:**
- None

**Minor changes to note:**
- Fixes the broken sonar cloud link on the README

**Tests for the changes:**
- N/A

**Other comments:**
- None

Closes #200 
