### PR TITLE
[NEMO-358] Recycling vertex ids while cloning a vertex 

### DIFF
--- a/common/src/main/java/org/apache/nemo/common/ir/IdManager.java
+++ b/common/src/main/java/org/apache/nemo/common/ir/IdManager.java
@@ -52,6 +52,7 @@ public final class IdManager {
 
   /**
    * Save the vertex id for the vertices that can be cloned later on.
+   * WARN: this should guarantee that the vertex is no longer used, otherwise, it would result in duplicate IDs.
    * @param v the original vertex that is to be cloned later on (RootLoopVertex's vertex).
    * @param id The IDs of the identical vertices.
    */
@@ -63,6 +64,8 @@ public final class IdManager {
   /**
    * Used for cloning vertices. If an existing ID exists, it returns the unused ID,
    * otherwise simply acts as the newVertexId method.
+   * WARN: the #saveVertexId method should no longer use the ID saved at that moment,
+   * in order for this method to work correctly.
    * @param v the vertex to get the ID for.
    * @return the ID for the vertex.
    */

--- a/common/src/main/java/org/apache/nemo/common/ir/vertex/IRVertex.java
+++ b/common/src/main/java/org/apache/nemo/common/ir/vertex/IRVertex.java
@@ -50,9 +50,9 @@ public abstract class IRVertex extends Vertex implements Cloneable<IRVertex> {
    * @param that the source object for copying
    */
   public IRVertex(final IRVertex that) {
-    super(IdManager.newVertexId());
+    super(IdManager.getVertexId(that));
     this.executionProperties = ExecutionPropertyMap.of(this);
-    that.getExecutionProperties().forEachProperties(this::setProperty);
+    that.copyExecutionPropertiesTo(this);
   }
 
   /**

--- a/common/src/main/java/org/apache/nemo/common/ir/vertex/LoopVertex.java
+++ b/common/src/main/java/org/apache/nemo/common/ir/vertex/LoopVertex.java
@@ -72,7 +72,7 @@ public final class LoopVertex extends IRVertex {
    *
    * @param that the source object for copying
    */
-  public LoopVertex(final LoopVertex that) {
+  private LoopVertex(final LoopVertex that) {
     super(that);
     this.compositeTransformFullName = new String(that.compositeTransformFullName);
     // Copy all elements to the clone

--- a/common/src/main/java/org/apache/nemo/common/ir/vertex/OperatorVertex.java
+++ b/common/src/main/java/org/apache/nemo/common/ir/vertex/OperatorVertex.java
@@ -41,8 +41,8 @@ public class OperatorVertex extends IRVertex {
    * Copy Constructor of OperatorVertex.
    * @param that the source object for copying
    */
-  public OperatorVertex(final OperatorVertex that) {
-    super();
+  private OperatorVertex(final OperatorVertex that) {
+    super(that);
     this.transform = that.transform;
   }
 


### PR DESCRIPTION
JIRA: [NEMO-358: Recycling vertex ids while cloning a vertex](https://issues.apache.org/jira/projects/NEMO/issues/NEMO-358)

**Major changes:**
- Implementation on the IDManager so that it saves the IDs that are no longer used, to be reused later on.
- Fixes the LoopExtractionPass (where cloning occurs) to meet with the new implementations.

**Minor changes to note:**
- None

**Tests for the changes:**
- Existing tests confirm the changes.

**Other comments:**
- None

Closes #201 