### PR TITLE
[NEMO-369] DirectByteArrayOutputStream usage refactoring

### DIFF
--- a/common/src/main/java/org/apache/nemo/common/DirectByteArrayOutputStream.java
+++ b/common/src/main/java/org/apache/nemo/common/DirectByteArrayOutputStream.java
@@ -44,7 +44,7 @@ public final class DirectByteArrayOutputStream extends ByteArrayOutputStream {
 
   /**
    * Note that serializedBytes include invalid bytes.
-   * So we have to use it with the actualLength by using size() whenever needed
+   * So we have to use it with the actualLength by using size() whenever needed.
    * @return the buffer where data is stored.
    */
   public byte[] getBufDirectly() {

--- a/common/src/main/java/org/apache/nemo/common/DirectByteArrayOutputStream.java
+++ b/common/src/main/java/org/apache/nemo/common/DirectByteArrayOutputStream.java
@@ -47,11 +47,4 @@ public final class DirectByteArrayOutputStream extends ByteArrayOutputStream {
   public byte[] getBufDirectly() {
     return buf;
   }
-
-  /**
-   * @return the number of valid bytes in the buffer.
-   */
-  public int getCount() {
-    return count;
-  }
 }

--- a/common/src/main/java/org/apache/nemo/common/DirectByteArrayOutputStream.java
+++ b/common/src/main/java/org/apache/nemo/common/DirectByteArrayOutputStream.java
@@ -23,6 +23,7 @@ import java.io.ByteArrayOutputStream;
 /**
  * This class represents a custom implementation of {@link ByteArrayOutputStream},
  * which enables to get bytes buffer directly (without memory copy).
+ * TODO #370: Substitute ByteArrayOutputStream with java.nio.ByteBuffer
  */
 public final class DirectByteArrayOutputStream extends ByteArrayOutputStream {
 
@@ -42,6 +43,8 @@ public final class DirectByteArrayOutputStream extends ByteArrayOutputStream {
   }
 
   /**
+   * Note that serializedBytes include invalid bytes.
+   * So we have to use it with the actualLength whenever needed
    * @return the buffer where data is stored.
    */
   public byte[] getBufDirectly() {

--- a/common/src/main/java/org/apache/nemo/common/DirectByteArrayOutputStream.java
+++ b/common/src/main/java/org/apache/nemo/common/DirectByteArrayOutputStream.java
@@ -44,7 +44,7 @@ public final class DirectByteArrayOutputStream extends ByteArrayOutputStream {
 
   /**
    * Note that serializedBytes include invalid bytes.
-   * So we have to use it with the actualLength whenever needed
+   * So we have to use it with the actualLength by using size() whenever needed
    * @return the buffer where data is stored.
    */
   public byte[] getBufDirectly() {

--- a/common/src/main/java/org/apache/nemo/common/coder/BytesDecoderFactory.java
+++ b/common/src/main/java/org/apache/nemo/common/coder/BytesDecoderFactory.java
@@ -88,7 +88,7 @@ public final class BytesDecoderFactory implements DecoderFactory<byte[]> {
         b = inputStream.read();
       }
 
-      final int lengthToRead = byteOutputStream.getCount();
+      final int lengthToRead = byteOutputStream.size();
       if (lengthToRead == 0) {
         if (!returnedArray) {
           returnedArray = true;
@@ -97,8 +97,7 @@ public final class BytesDecoderFactory implements DecoderFactory<byte[]> {
           throw new EOFException("EoF (empty partition)!"); // TODO #120: use EOF exception instead of IOException.
         }
       }
-      final byte[] resultBytes = new byte[lengthToRead]; // Read the size of this byte array.
-      System.arraycopy(byteOutputStream.getBufDirectly(), 0, resultBytes, 0, lengthToRead);
+      final byte[] resultBytes = byteOutputStream.toByteArray();
 
       returnedArray = true;
       return resultBytes;

--- a/runtime/executor/src/main/java/org/apache/nemo/runtime/executor/data/DataUtil.java
+++ b/runtime/executor/src/main/java/org/apache/nemo/runtime/executor/data/DataUtil.java
@@ -119,7 +119,7 @@ public final class DataUtil {
         // We need to close wrappedStream on here, because DirectByteArrayOutputStream:getBufDirectly() returns
         // inner buffer directly, which can be an unfinished(not flushed) buffer.
         wrappedStream.close();
-        // Note that serializedBytes include invalid bytes. So we have to use it with the actualLength whenever needed
+        // Note that serializedBytes include invalid bytes. So we have to use it with the actualLength by using size() whenever needed
         final byte[] serializedBytes = bytesOutputStream.getBufDirectly();
         final int actualLength = bytesOutputStream.size();
         serializedPartitions.add(

--- a/runtime/executor/src/main/java/org/apache/nemo/runtime/executor/data/DataUtil.java
+++ b/runtime/executor/src/main/java/org/apache/nemo/runtime/executor/data/DataUtil.java
@@ -119,7 +119,8 @@ public final class DataUtil {
         // We need to close wrappedStream on here, because DirectByteArrayOutputStream:getBufDirectly() returns
         // inner buffer directly, which can be an unfinished(not flushed) buffer.
         wrappedStream.close();
-        // Note that serializedBytes include invalid bytes. So we have to use it with the actualLength by using size() whenever needed
+        // Note that serializedBytes include invalid bytes.
+        // So we have to use it with the actualLength by using size() whenever needed.
         final byte[] serializedBytes = bytesOutputStream.getBufDirectly();
         final int actualLength = bytesOutputStream.size();
         serializedPartitions.add(

--- a/runtime/executor/src/main/java/org/apache/nemo/runtime/executor/data/DataUtil.java
+++ b/runtime/executor/src/main/java/org/apache/nemo/runtime/executor/data/DataUtil.java
@@ -119,8 +119,9 @@ public final class DataUtil {
         // We need to close wrappedStream on here, because DirectByteArrayOutputStream:getBufDirectly() returns
         // inner buffer directly, which can be an unfinished(not flushed) buffer.
         wrappedStream.close();
+        // Note that serializedBytes include invalid bytes. So we have to use it with the actualLength whenever needed
         final byte[] serializedBytes = bytesOutputStream.getBufDirectly();
-        final int actualLength = bytesOutputStream.getCount();
+        final int actualLength = bytesOutputStream.size();
         serializedPartitions.add(
             new SerializedPartition<>(partitionToConvert.getKey(), serializedBytes, actualLength));
       }

--- a/runtime/executor/src/main/java/org/apache/nemo/runtime/executor/data/partition/SerializedPartition.java
+++ b/runtime/executor/src/main/java/org/apache/nemo/runtime/executor/data/partition/SerializedPartition.java
@@ -117,7 +117,7 @@ public final class SerializedPartition<K> implements Partition<byte[], K> {
       wrappedStream.close();
       this.serializedData = bytesOutputStream.getBufDirectly();
 
-      this.length = bytesOutputStream.getCount();
+      this.length = bytesOutputStream.size();
       this.committed = true;
     }
   }


### PR DESCRIPTION
JIRA: [NEMO-369: DirectByteArrayOutputStream usage refactoring](https://issues.apache.org/jira/projects/NEMO/issues/NEMO-369)

**Major changes:**
- Replaced usage of duplicated method getCount() to size()
- deleted getCount() method

**Minor changes to note:**
- None

**Tests for the changes:**
- None

**Other comments:**
- None
