### PR TITLE
[NEMO-368] include all jar files for global libraries

### DIFF
--- a/client/src/main/java/org/apache/nemo/client/JobLauncher.java
+++ b/client/src/main/java/org/apache/nemo/client/JobLauncher.java
@@ -366,7 +366,7 @@ public final class JobLauncher {
     final String jobId = injector.getNamedInstance(JobConf.JobId.class);
     final int driverMemory = injector.getNamedInstance(JobConf.DriverMemMb.class);
     return DriverConfiguration.CONF
-      .set(DriverConfiguration.GLOBAL_LIBRARIES, EnvironmentUtils.getClassLocation(NemoDriver.class))
+      .setMultiple(DriverConfiguration.GLOBAL_LIBRARIES, EnvironmentUtils.getAllClasspathJars())
       .set(DriverConfiguration.ON_DRIVER_STARTED, NemoDriver.StartHandler.class)
       .set(DriverConfiguration.ON_EVALUATOR_ALLOCATED, NemoDriver.AllocatedEvaluatorHandler.class)
       .set(DriverConfiguration.ON_CONTEXT_ACTIVE, NemoDriver.ActiveContextHandler.class)


### PR DESCRIPTION
JIRA: [NEMO-368: NEMO-353 breaks the application from running in YARN environments](https://issues.apache.org/jira/projects/NEMO/issues/NEMO-368)

**Major changes:**
- includes all jar files in the class path when starting NemoDriver

