### PR TITLE
[NEMO-379] Change javadoc goal to a proper one

### DIFF
--- a/compiler/test/src/test/java/org/apache/nemo/compiler/frontend/beam/transform/TestOutputCollector.java
+++ b/compiler/test/src/test/java/org/apache/nemo/compiler/frontend/beam/transform/TestOutputCollector.java
@@ -29,7 +29,7 @@ import java.util.List;
 /**
  * Test output collector that collects data and watermarks.
  *
- * @param <T>
+ * @param <T> type of the output.
  */
 final class TestOutputCollector<T> implements OutputCollector<WindowedValue<T>> {
   public final List<WindowedValue<T>> outputs;

--- a/pom.xml
+++ b/pom.xml
@@ -285,7 +285,7 @@ under the License.
           <execution>
             <id>test-javadoc</id>
             <goals>
-              <goal>javadoc</goal>
+              <goal>test-javadoc</goal>
             </goals>
             <phase>validate</phase>
           </execution>

--- a/runtime/executor/src/test/java/org/apache/nemo/runtime/executor/data/BlockStoreTest.java
+++ b/runtime/executor/src/test/java/org/apache/nemo/runtime/executor/data/BlockStoreTest.java
@@ -115,6 +115,8 @@ public final class BlockStoreTest {
 
   /**
    * Generates the ids and the data which will be used for the block store tests.
+   *
+   * @throws Exception exception on the way.
    */
   @Before
   public void setUp() throws Exception {
@@ -220,6 +222,8 @@ public final class BlockStoreTest {
 
   /**
    * Test {@link MemoryStore}.
+   *
+   * @throws Exception exception on the way.
    */
   @Test(timeout = 10000)
   public void testMemoryStore() throws Exception {
@@ -233,6 +237,8 @@ public final class BlockStoreTest {
 
   /**
    * Test {@link SerializedMemoryStore}.
+   *
+   * @throws Exception exception on the way.
    */
   @Test(timeout = 10000)
   public void testSerMemoryStore() throws Exception {
@@ -246,6 +252,8 @@ public final class BlockStoreTest {
 
   /**
    * Test {@link LocalFileStore}.
+   *
+   * @throws Exception exception on the way.
    */
   @Test(timeout = 10000)
   public void testLocalFileStore() throws Exception {
@@ -265,6 +273,8 @@ public final class BlockStoreTest {
    * Test {@link GlusterFileStore}.
    * Actually, we cannot create a virtual GFS volume in here.
    * Instead, this test mimics the GFS circumstances by doing the read and write on separate file stores.
+   *
+   * @throws Exception exception on the way.
    */
   @Test(timeout = 10000)
   public void testGlusterFileStore() throws Exception {

--- a/runtime/executor/src/test/java/org/apache/nemo/runtime/executor/data/BlockTest.java
+++ b/runtime/executor/src/test/java/org/apache/nemo/runtime/executor/data/BlockTest.java
@@ -45,6 +45,8 @@ public final class BlockTest {
 
   /**
    * Generates the test data and serializer.
+   *
+   * @throws Exception exception on the way.
    */
   @Before
   public void setUp() throws Exception {
@@ -62,6 +64,8 @@ public final class BlockTest {
 
   /**
    * Test {@link NonSerializedMemoryBlock}.
+   *
+   * @throws Exception exception on the way.
    */
   @Test(timeout = 10000)
   public void testNonSerializedMemoryBlock() throws Exception {
@@ -71,6 +75,8 @@ public final class BlockTest {
 
   /**
    * Test {@link org.apache.nemo.runtime.executor.data.block.SerializedMemoryBlock}.
+   *
+   * @throws Exception exception on the way.
    */
   @Test(timeout = 10000)
   public void testSerializedMemoryBlock() throws Exception {
@@ -80,6 +86,8 @@ public final class BlockTest {
 
   /**
    * Test {@link FileBlock}.
+   *
+   * @throws Exception exception on the way.
    */
   @Test(timeout = 10000)
   public void testFileBlock() throws Exception {

--- a/runtime/executor/src/test/java/org/apache/nemo/runtime/executor/task/TaskExecutorTest.java
+++ b/runtime/executor/src/test/java/org/apache/nemo/runtime/executor/task/TaskExecutorTest.java
@@ -135,6 +135,8 @@ public final class TaskExecutorTest {
 
   /**
    * Test source vertex data fetching.
+   *
+   * @throws Exception exception on the way.
    */
   @Test()
   public void testSourceVertexDataFetching() throws Exception {
@@ -191,6 +193,8 @@ public final class TaskExecutorTest {
 
   /**
    * Test invalid parameter failure.
+   *
+   * @throws Exception exception on the way.
    */
   @Test()
   public void testInvalidInputData() throws Exception {
@@ -208,6 +212,8 @@ public final class TaskExecutorTest {
 
   /**
    * This test emits data and watermark by emulating an unbounded source readable.
+   *
+   * @throws Exception exception on the way.
    */
   @Test()
   public void testUnboundedSourceVertexDataFetching() throws Exception {
@@ -255,6 +261,8 @@ public final class TaskExecutorTest {
 
   /**
    * Test parent task data fetching.
+   *
+   * @throws Exception exception on the way.
    */
   @Test(timeout = 5000)
   public void testParentTaskDataFetching() throws Exception {
@@ -294,8 +302,8 @@ public final class TaskExecutorTest {
 
   /**
    * The DAG of the task to test will looks like:
-   * source1 -> vertex1 -> vertex2
-   * source2 -> vertex3 ->
+   * source1 - vertex1 - vertex2
+   * source2 - vertex3 -
    * <p>
    * The vertex2 has two incoming edges (from vertex1 and vertex3)
    * and we test if TaskExecutor handles data and watermarks correctly in this situation.
@@ -304,6 +312,8 @@ public final class TaskExecutorTest {
    * source2 emits watermarks:  1000(ts)                                     2200 (ts)
    * <p>
    * The vertex2 should receive and emits watermarks 500, 600, 1000, 1800, and 2200
+   *
+   * @throws Exception exception on the way.
    */
   @Test()
   public void testMultipleIncomingEdges() throws Exception {
@@ -386,11 +396,13 @@ public final class TaskExecutorTest {
 
   /**
    * The DAG of the task to test will looks like:
-   * parent task -> task (vertex 1 -> task 2) -> child task
+   * parent task - task (vertex 1 - task 2) - child task
    * <p>
    * The output data from task 1 will be split according to source parallelism through {@link ParentTaskReaderAnswer}.
    * Because of this, task 1 will process multiple partitions and emit data in multiple times also.
    * On the other hand, task 2 will receive the output data once and produce a single output.
+   *
+   * @throws Exception exception on the way.
    */
   @Test(timeout = 5000)
   public void testTwoOperators() throws Exception {
@@ -470,6 +482,8 @@ public final class TaskExecutorTest {
    * <p>
    * emit(element) and emit(dstVertexId, element) used together. emit(element) routes results to main output children,
    * and emit(dstVertexId, element) routes results to corresponding additional output children.
+   *
+   * @throws Exception exception on the way.
    */
   @Test(timeout = 5000)
   public void testAdditionalOutputs() throws Exception {

--- a/runtime/master/src/test/java/org/apache/nemo/runtime/master/BlockManagerMasterTest.java
+++ b/runtime/master/src/test/java/org/apache/nemo/runtime/master/BlockManagerMasterTest.java
@@ -81,7 +81,7 @@ public final class BlockManagerMasterTest {
   /**
    * Test scenario where block becomes committed and then lost.
    *
-   * @throws Exception
+   * @throws Exception exception on the way.
    */
   @Test
   public void testLostAfterCommit() throws Exception {
@@ -112,7 +112,7 @@ public final class BlockManagerMasterTest {
   /**
    * Test scenario where producer task fails.
    *
-   * @throws Exception
+   * @throws Exception exception on the way.
    */
   @Test
   public void testBeforeAfterCommit() throws Exception {

--- a/runtime/master/src/test/java/org/apache/nemo/runtime/master/PlanStateManagerTest.java
+++ b/runtime/master/src/test/java/org/apache/nemo/runtime/master/PlanStateManagerTest.java
@@ -66,6 +66,8 @@ public final class PlanStateManagerTest {
   /**
    * This method builds a physical DAG starting from an IR DAG and submits it to {@link PlanStateManager}.
    * State changes are explicitly called to check whether states are managed correctly or not.
+   *
+   * @throws Exception exception on the way.
    */
   @Test
   public void testPhysicalPlanStateChanges() throws Exception {
@@ -97,6 +99,8 @@ public final class PlanStateManagerTest {
 
   /**
    * Test whether the methods waiting for the finish of the plan works properly.
+   *
+   * @throws Exception exception on the way.
    */
   @Test(timeout = 4000)
   public void testWaitUntilFinish() throws Exception {

--- a/runtime/master/src/test/java/org/apache/nemo/runtime/master/scheduler/BatchSchedulerTest.java
+++ b/runtime/master/src/test/java/org/apache/nemo/runtime/master/scheduler/BatchSchedulerTest.java
@@ -119,6 +119,8 @@ public final class BatchSchedulerTest {
   /**
    * This method builds a physical DAG starting from an IR DAG and submits it to {@link BatchScheduler}.
    * Task state changes are explicitly submitted to scheduler instead of executor messages.
+   *
+   * @throws Exception exception on the way.
    */
   @Test(timeout = 10000)
   public void testPull() throws Exception {
@@ -129,6 +131,8 @@ public final class BatchSchedulerTest {
   /**
    * This method builds a physical DAG starting from an IR DAG and submits it to {@link BatchScheduler}.
    * Task state changes are explicitly submitted to scheduler instead of executor messages.
+   *
+   * @throws Exception exception on the way.
    */
   @Test(timeout = 10000)
   public void testPush() throws Exception {

--- a/runtime/master/src/test/java/org/apache/nemo/runtime/master/scheduler/LocalitySchedulingConstraintTest.java
+++ b/runtime/master/src/test/java/org/apache/nemo/runtime/master/scheduler/LocalitySchedulingConstraintTest.java
@@ -67,6 +67,8 @@ public final class LocalitySchedulingConstraintTest {
   /**
    * {@link LocalitySchedulingConstraint} should fail to schedule a {@link Task} when
    * there are no executors in appropriate location(s).
+   *
+   * @throws InjectionException exception on the way.
    */
   @Test
   public void testSourceLocationAwareSchedulingNotAvailable() throws InjectionException {
@@ -87,6 +89,8 @@ public final class LocalitySchedulingConstraintTest {
   /**
    * {@link LocalitySchedulingConstraint} should properly schedule {@link Task}s
    * with multiple source locations.
+   *
+   * @throws InjectionException exception on the way.
    */
   @Test
   public void testSourceLocationAwareSchedulingWithMultiSource() throws InjectionException {


### PR DESCRIPTION
JIRA: [NEMO-379: Change javadoc goal to a proper one](https://issues.apache.org/jira/projects/NEMO/issues/NEMO-379)

**Major changes:**
- Change javadoc test command from `javadoc` to `test-javadoc`. This prevents tests from creating unwanted javdoc files, caused by #139 .

**Minor changes to note:**
- None

**Tests for the changes:**
- None

**Other comments:**
- None

Closes #212 