### PR TITLE
[NEMO-383] Implement DirectByteBufferOutputStream for Off-heap SerializedMemoryStore

### DIFF
--- a/common/src/main/java/org/apache/nemo/common/DirectByteBufferOutputStream.java
+++ b/common/src/main/java/org/apache/nemo/common/DirectByteBufferOutputStream.java
@@ -43,7 +43,7 @@ public class DirectByteBufferOutputStream extends OutputStream {
   /**
    * Constructor specifying the {@code pageSize}.
    *
-   * @param pageSize should be greater than 4KB and power of 2.
+   * @param pageSize should be a power of 2 and greater than 4KB.
    */
   public DirectByteBufferOutputStream(final int pageSize){
     if(pageSize < 4096 || (pageSize & (pageSize - 1)) != 0){
@@ -120,7 +120,7 @@ public class DirectByteBufferOutputStream extends OutputStream {
 
   /**
    * Creates a byte array that contains the whole content
-   * written in this output stream.
+   * currently written in this output stream.
    *
    * @return the current contents of this output stream, as byte array.
    */
@@ -156,7 +156,6 @@ public class DirectByteBufferOutputStream extends OutputStream {
 
   /**
    * Closes this output stream and releases resources.
-   *
    */
   @Override
   public void close() {

--- a/common/src/main/java/org/apache/nemo/common/DirectByteBufferOutputStream.java
+++ b/common/src/main/java/org/apache/nemo/common/DirectByteBufferOutputStream.java
@@ -22,17 +22,17 @@ package org.apache.nemo.common;
 import java.io.OutputStream;
 import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 
 
 /**
- * 
+ *
  */
 public class DirectByteBufferOutputStream extends OutputStream {
 
   private ByteBuffer buf;
-  private List<ByteBuffer> dataList;
+  private LinkedList<ByteBuffer> dataList = new LinkedList<>();
   private static final int pageSize = 4096;
 
   public DirectByteBufferOutputStream(){
@@ -45,7 +45,6 @@ public class DirectByteBufferOutputStream extends OutputStream {
         + size);
     }
     this.buf = ByteBuffer.allocateDirect(size);
-    this.dataList = new ArrayList<>();
   }
 
   @Override

--- a/common/src/main/java/org/apache/nemo/common/DirectByteBufferOutputStream.java
+++ b/common/src/main/java/org/apache/nemo/common/DirectByteBufferOutputStream.java
@@ -32,7 +32,7 @@ public final class DirectByteBufferOutputStream extends OutputStream {
 
   private LinkedList<ByteBuffer> dataList = new LinkedList<>();
   private static final int DEFAULT_PAGE_SIZE = 4096;
-  private int pageSize;
+  private final int pageSize;
   private ByteBuffer currentBuf;
 
 
@@ -54,7 +54,7 @@ public final class DirectByteBufferOutputStream extends OutputStream {
     if (size < DEFAULT_PAGE_SIZE || (size & (size - 1)) != 0) {
       throw new IllegalArgumentException("Invalid pageSize");
     }
-    pageSize = size;
+    this.pageSize = size;
   }
 
   /**

--- a/common/src/main/java/org/apache/nemo/common/DirectByteBufferOutputStream.java
+++ b/common/src/main/java/org/apache/nemo/common/DirectByteBufferOutputStream.java
@@ -31,15 +31,17 @@ import java.util.List;
 public final class DirectByteBufferOutputStream extends OutputStream {
 
   private LinkedList<ByteBuffer> dataList = new LinkedList<>();
-  private static int pageSize = 4096;
+  private static final int DEFAULT_PAGE_SIZE = 4096;
+  private int pageSize;
   private ByteBuffer currentBuf;
+
 
   /**
    * Default constructor.
    * Sets the {@code pageSize} as default size of 4096 bytes.
    */
   public DirectByteBufferOutputStream() {
-    this(pageSize);
+    this(DEFAULT_PAGE_SIZE);
   }
 
   /**
@@ -49,7 +51,7 @@ public final class DirectByteBufferOutputStream extends OutputStream {
    * @param size should be a power of 2 and greater than or equal to 4096.
    */
   public DirectByteBufferOutputStream(final int size) {
-    if (size < 4096 || (size & (size - 1)) != 0) {
+    if (size < DEFAULT_PAGE_SIZE || (size & (size - 1)) != 0) {
       throw new IllegalArgumentException("Invalid pageSize");
     }
     pageSize = size;

--- a/common/src/main/java/org/apache/nemo/common/DirectByteBufferOutputStream.java
+++ b/common/src/main/java/org/apache/nemo/common/DirectByteBufferOutputStream.java
@@ -21,6 +21,7 @@ package org.apache.nemo.common;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.util.LinkedList;
+import java.util.List;
 
 /**
  * This class is a customized output stream implementation backed by
@@ -29,7 +30,7 @@ import java.util.LinkedList;
  */
 public final class DirectByteBufferOutputStream extends OutputStream {
 
-  private final LinkedList<ByteBuffer> dataList = new LinkedList<>();
+  private LinkedList<ByteBuffer> dataList = new LinkedList<>();
   private static int pageSize = 4096;
   private ByteBuffer currentBuf;
 
@@ -156,12 +157,17 @@ public final class DirectByteBufferOutputStream extends OutputStream {
 
   /**
    * Returns the list of {@code ByteBuffer}s that contains the written data.
-   * Note that the returned {@code ByteBuffer}s are in write mode.
+   * Note that by calling this method, the existing list of {@code ByteBuffer}s is cleared.
    *
    * @return the {@code LinkedList} of {@code ByteBuffer}s.
    */
-  public LinkedList<ByteBuffer> getBufferList() {
-    return dataList;
+  public List<ByteBuffer> getBufferList() {
+    List<ByteBuffer> result = dataList;
+    dataList = new LinkedList<>();
+    for (final ByteBuffer buffer : result) {
+      buffer.flip();
+    }
+    return result;
   }
 
   /**

--- a/common/src/main/java/org/apache/nemo/common/DirectByteBufferOutputStream.java
+++ b/common/src/main/java/org/apache/nemo/common/DirectByteBufferOutputStream.java
@@ -25,41 +25,40 @@ import java.util.LinkedList;
 /**
  * This class is a customized output stream implementation backed by
  * {@link ByteBuffer}, which utilizes off heap memory when writing the data.
- * Memory is allocated when needed by the specified {@code pageSize}.
+ * Memory is allocated when needed by the specified {@code PAGE_SIZE}.
  */
 public final class DirectByteBufferOutputStream extends OutputStream {
 
   private final LinkedList<ByteBuffer> dataList = new LinkedList<>();
-  private static int pageSize = 4096;
+  private static int PAGE_SIZE = 4096;
   private ByteBuffer currentBuf;
 
   /**
    * Default constructor.
-   * Sets the {@code pageSize} as default size of 4KB.
+   * Sets the {@code PAGE_SIZE} as default size of 4096 bytes.
    */
   public DirectByteBufferOutputStream() {
-    this(pageSize);
+    this(PAGE_SIZE);
   }
 
   /**
    * Constructor specifying the {@code size}.
-   * Sets the {@code pageSize} as {@code size}.
+   * Sets the {@code PAGE_SIZE} as {@code size}.
    *
    * @param size should be a power of 2 and greater than or equal to 4096.
    */
   public DirectByteBufferOutputStream(final int size) {
     if (size < 4096 || (size & (size - 1)) != 0) {
-      throw new IllegalArgumentException("Invalid pageSize");
+      throw new IllegalArgumentException("Invalid PAGE_SIZE");
     }
-    pageSize = size;
+    PAGE_SIZE = size;
   }
 
   /**
-   * Allocates new {@link ByteBuffer} with the capacity equal to
-   * {@code pageSize}.
+   * Allocates new {@link ByteBuffer} with the capacity equal to {@code PAGE_SIZE}.
    */
   private void newLastBuffer() {
-    dataList.addLast(ByteBuffer.allocateDirect(pageSize));
+    dataList.addLast(ByteBuffer.allocateDirect(PAGE_SIZE));
   }
 
   /**
@@ -120,7 +119,7 @@ public final class DirectByteBufferOutputStream extends OutputStream {
 
   /**
    * Creates a byte array that contains the whole content currently written in this output stream.
-   * Note that this method causes array copy which could degrade the overall performance.
+   * Note that this method causes array copy which could degrade performance.
    *
    * @return the current contents of this output stream, as byte array.
    */
@@ -131,10 +130,10 @@ public final class DirectByteBufferOutputStream extends OutputStream {
     }
 
     ByteBuffer lastBuf = dataList.getLast();
-    // pageSize equals the size of the data filled in the ByteBuffers
+    // PAGE_SIZE equals the size of the data filled in the ByteBuffers
     // except for the last ByteBuffer. The size of the data in the
     // ByteBuffer can be obtained by calling ByteBuffer.position().
-    final int arraySize = pageSize * (dataList.size() - 1) + lastBuf.position();
+    final int arraySize = PAGE_SIZE * (dataList.size() - 1) + lastBuf.position();
     final byte[] byteArray = new byte[arraySize];
     int start = 0;
     int byteToWrite;
@@ -155,10 +154,18 @@ public final class DirectByteBufferOutputStream extends OutputStream {
   }
 
   /**
-   * Closes this output stream and releases resources.
+   * Returns the list of {@code ByteBuffer}s that contains the written data.
+   * Note that the returned {@code ByteBuffer}s are in write mode.
+   *
+   * @return the {@code LinkedList} of {@code ByteBuffer}s.
    */
-  @Override
+  public LinkedList<ByteBuffer> getBufferList() {
+    return dataList;
+  }
+
+  /**
+   * Closing this output stream has no effect.
+   */
   public void close() {
-    dataList.clear();
   }
 }

--- a/common/src/main/java/org/apache/nemo/common/DirectByteBufferOutputStream.java
+++ b/common/src/main/java/org/apache/nemo/common/DirectByteBufferOutputStream.java
@@ -36,7 +36,7 @@ public class DirectByteBufferOutputStream extends OutputStream {
    * Default constructor.
    * Sets the {@code pageSize} as default size of 4KB.
    */
-  public DirectByteBufferOutputStream(){
+  public DirectByteBufferOutputStream() {
     pageSize = 4096;
   }
 
@@ -45,15 +45,16 @@ public class DirectByteBufferOutputStream extends OutputStream {
    *
    * @param pageSize should be a power of 2 and greater than 4KB.
    */
-  public DirectByteBufferOutputStream(final int pageSize){
-    if(pageSize < 4096 || (pageSize & (pageSize - 1)) != 0){
+  public DirectByteBufferOutputStream(final int pageSize) {
+    if (pageSize < 4096 || (pageSize & (pageSize - 1)) != 0) {
       throw new IllegalArgumentException("Invalid pageSize");
     }
     this.pageSize = pageSize;
   }
 
   /**
-   * Allocates new {@link ByteBuffer} with the capacity equal to {@code pageSize}.
+   * Allocates new {@link ByteBuffer} with the capacity equal to
+   * {@code pageSize}.
    */
   private void newLastBuffer() {
     dataList.addLast(ByteBuffer.allocateDirect(pageSize));
@@ -66,12 +67,12 @@ public class DirectByteBufferOutputStream extends OutputStream {
    */
   @Override
   public void write(final int b) {
-    ByteBuffer currentBuf = (dataList.isEmpty() ? null: dataList.getLast());
-    if (currentBuf == null || currentBuf.remaining() <= 0){
+    ByteBuffer currentBuf = (dataList.isEmpty() ? null : dataList.getLast());
+    if (currentBuf == null || currentBuf.remaining() <= 0) {
       newLastBuffer();
       currentBuf = dataList.getLast();
     }
-    currentBuf.put((byte)b);
+    currentBuf.put((byte) b);
   }
 
   /**
@@ -94,13 +95,12 @@ public class DirectByteBufferOutputStream extends OutputStream {
    * @param   len   the number of bytes to write.
    */
   @Override
-  public void write(final byte[] b, final int off, final int len){
+  public void write(final byte[] b, final int off, final int len) {
     int byteToWrite = len;
     int offset = off;
-
-    ByteBuffer currentBuf = (dataList.isEmpty() ? null: dataList.getLast());
-    while(byteToWrite > 0) {
-      if (currentBuf == null || currentBuf.remaining() <= 0){
+    ByteBuffer currentBuf = (dataList.isEmpty() ? null : dataList.getLast());
+    while (byteToWrite > 0) {
+      if (currentBuf == null || currentBuf.remaining() <= 0) {
         newLastBuffer();
         currentBuf = dataList.getLast();
       }
@@ -132,16 +132,16 @@ public class DirectByteBufferOutputStream extends OutputStream {
 
     ByteBuffer lastBuf = dataList.getLast();
     // pageSize equals the size of the data filled in the ByteBuffers
-    // except for the last ByteBuffer. The size of the data in the last ByteBuffer
-    // can be obtained by calling ByteBuffer.position().
+    // except for the last ByteBuffer. The size of the data in the
+    // ByteBuffer can be obtained by calling ByteBuffer.position().
     final int arraySize = pageSize * (dataList.size() - 1) + lastBuf.position();
     final byte[] byteArray = new byte[arraySize];
     int start = 0;
     int byteToWrite;
 
-    for(ByteBuffer temp : dataList) {
+    for (ByteBuffer temp : dataList) {
       // ByteBuffer has to be shifted to read mode by calling ByteBuffer.flip(),
-      // which sets its limit to the current position and sets the position to 0.
+      // which sets limit to the current position and sets the position to 0.
       // Note that capacity remains unchanged.
       temp.flip();
       byteToWrite = temp.remaining();

--- a/common/src/main/java/org/apache/nemo/common/DirectByteBufferOutputStream.java
+++ b/common/src/main/java/org/apache/nemo/common/DirectByteBufferOutputStream.java
@@ -55,6 +55,7 @@ public final class DirectByteBufferOutputStream extends OutputStream {
       throw new IllegalArgumentException("Invalid pageSize");
     }
     this.pageSize = size;
+    newLastBuffer();
   }
 
   /**
@@ -71,8 +72,8 @@ public final class DirectByteBufferOutputStream extends OutputStream {
    */
   @Override
   public void write(final int b) {
-    currentBuf = (dataList.isEmpty() ? null : dataList.getLast());
-    if (currentBuf == null || currentBuf.remaining() <= 0) {
+    currentBuf = dataList.getLast();
+    if (currentBuf.remaining() <= 0) {
       newLastBuffer();
       currentBuf = dataList.getLast();
     }
@@ -101,9 +102,9 @@ public final class DirectByteBufferOutputStream extends OutputStream {
   public void write(final byte[] b, final int off, final int len) {
     int byteToWrite = len;
     int offset = off;
-    currentBuf = (dataList.isEmpty() ? null : dataList.getLast());
+    currentBuf = dataList.getLast();
     while (byteToWrite > 0) {
-      if (currentBuf == null || currentBuf.remaining() <= 0) {
+      if (currentBuf.remaining() <= 0) {
         newLastBuffer();
         currentBuf = dataList.getLast();
       }

--- a/common/src/main/java/org/apache/nemo/common/DirectByteBufferOutputStream.java
+++ b/common/src/main/java/org/apache/nemo/common/DirectByteBufferOutputStream.java
@@ -18,13 +18,9 @@
  */
 package org.apache.nemo.common;
 
-
-import com.sun.istack.NotNull;
-
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.util.LinkedList;
-
 
 /**
  * This class is a customized output stream implementation backed by

--- a/common/src/main/java/org/apache/nemo/common/DirectByteBufferOutputStream.java
+++ b/common/src/main/java/org/apache/nemo/common/DirectByteBufferOutputStream.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.nemo.common;
+
+
+import java.io.OutputStream;
+import java.nio.BufferOverflowException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+
+
+/**
+ * 
+ */
+public class DirectByteBufferOutputStream extends OutputStream {
+
+  private ByteBuffer buf;
+  private List<ByteBuffer> dataList;
+  private static final int pageSize = 4096;
+
+  public DirectByteBufferOutputStream(){
+    this(pageSize);
+  }
+
+  public DirectByteBufferOutputStream(int size){
+    if (size < 0) {
+      throw new IllegalArgumentException("Negative initial size: "
+        + size);
+    }
+    this.buf = ByteBuffer.allocateDirect(size);
+    this.dataList = new ArrayList<>();
+  }
+
+  @Override
+  public void write(int b){
+    if (!buf.hasRemaining()) {
+      throw new BufferOverflowException();
+    }
+    buf.put((byte) b);
+  }
+
+  /**
+   *
+   * @param b
+   */
+  @Override
+  public void write(byte[] b){
+    //TODO: Has to be implemented using list appending.
+
+    int length = b.length;
+    int offset = 0;
+
+    buf.put(b, offset, pageSize);
+    dataList.add(buf);
+    offset += pageSize;
+    length -= pageSize;
+
+    while(length > 0){
+      ByteBuffer temp = ByteBuffer.allocateDirect(pageSize);
+      temp.put(b, offset, pageSize);
+      offset += pageSize;
+      length -= pageSize;
+      dataList.add(temp);
+    }
+  }
+
+  /**
+   *
+   * @param b
+   * @param off
+   * @param len
+   */
+  @Override
+  public void write(byte[] b, int off, int len){
+    //TODO: Has to be implemented using list appending.
+
+    int length = len;
+    int offset = off;
+
+    buf.put(b, off, len);
+    dataList.add(buf);
+    offset += len;
+    length -= len;
+
+    while(length > 0){
+      ByteBuffer temp = ByteBuffer.allocateDirect(pageSize);
+      temp.put(b, offset, pageSize);
+      offset += pageSize;
+      length -= pageSize;
+      dataList.add(temp);
+    }
+  }
+
+  /**
+   *
+   */
+  public void grow(){
+
+    //TODO: Fill up the code to implement the mechanism of adding up the byte buffer when one is full.
+
+  }
+
+  /**
+   *
+   * @return
+   */
+  public byte[] toByteArray(){
+    byte[] byteArray = new byte[pageSize * dataList.size()];
+    int start = 0;
+
+    while(!dataList.isEmpty()){
+      ByteBuffer temp = dataList.remove(0);
+      temp.get(byteArray, start, pageSize);
+      start += pageSize;
+    }
+    return byteArray;
+  }
+
+  /**
+   *
+   * @return
+   */
+  public ByteBuffer getByteBuffer() { return buf; }
+
+}

--- a/common/src/main/java/org/apache/nemo/common/DirectByteBufferOutputStream.java
+++ b/common/src/main/java/org/apache/nemo/common/DirectByteBufferOutputStream.java
@@ -55,7 +55,7 @@ public class DirectByteBufferOutputStream extends OutputStream {
   /**
    * Allocates new {@link ByteBuffer} with the capacity equal to {@code pageSize}.
    */
-  public void newLastBuffer() {
+  private void newLastBuffer() {
     dataList.addLast(ByteBuffer.allocateDirect(pageSize));
   }
 

--- a/common/src/main/java/org/apache/nemo/common/DirectByteBufferOutputStream.java
+++ b/common/src/main/java/org/apache/nemo/common/DirectByteBufferOutputStream.java
@@ -25,40 +25,40 @@ import java.util.LinkedList;
 /**
  * This class is a customized output stream implementation backed by
  * {@link ByteBuffer}, which utilizes off heap memory when writing the data.
- * Memory is allocated when needed by the specified {@code PAGE_SIZE}.
+ * Memory is allocated when needed by the specified {@code pageSize}.
  */
 public final class DirectByteBufferOutputStream extends OutputStream {
 
   private final LinkedList<ByteBuffer> dataList = new LinkedList<>();
-  private static int PAGE_SIZE = 4096;
+  private static int pageSize = 4096;
   private ByteBuffer currentBuf;
 
   /**
    * Default constructor.
-   * Sets the {@code PAGE_SIZE} as default size of 4096 bytes.
+   * Sets the {@code pageSize} as default size of 4096 bytes.
    */
   public DirectByteBufferOutputStream() {
-    this(PAGE_SIZE);
+    this(pageSize);
   }
 
   /**
    * Constructor specifying the {@code size}.
-   * Sets the {@code PAGE_SIZE} as {@code size}.
+   * Sets the {@code pageSize} as {@code size}.
    *
    * @param size should be a power of 2 and greater than or equal to 4096.
    */
   public DirectByteBufferOutputStream(final int size) {
     if (size < 4096 || (size & (size - 1)) != 0) {
-      throw new IllegalArgumentException("Invalid PAGE_SIZE");
+      throw new IllegalArgumentException("Invalid pageSize");
     }
-    PAGE_SIZE = size;
+    pageSize = size;
   }
 
   /**
-   * Allocates new {@link ByteBuffer} with the capacity equal to {@code PAGE_SIZE}.
+   * Allocates new {@link ByteBuffer} with the capacity equal to {@code pageSize}.
    */
   private void newLastBuffer() {
-    dataList.addLast(ByteBuffer.allocateDirect(PAGE_SIZE));
+    dataList.addLast(ByteBuffer.allocateDirect(pageSize));
   }
 
   /**
@@ -120,6 +120,7 @@ public final class DirectByteBufferOutputStream extends OutputStream {
   /**
    * Creates a byte array that contains the whole content currently written in this output stream.
    * Note that this method causes array copy which could degrade performance.
+   * TODO #384: For performance issue, implement an input stream so that we do not have to use this method.
    *
    * @return the current contents of this output stream, as byte array.
    */
@@ -130,10 +131,10 @@ public final class DirectByteBufferOutputStream extends OutputStream {
     }
 
     ByteBuffer lastBuf = dataList.getLast();
-    // PAGE_SIZE equals the size of the data filled in the ByteBuffers
+    // pageSize equals the size of the data filled in the ByteBuffers
     // except for the last ByteBuffer. The size of the data in the
     // ByteBuffer can be obtained by calling ByteBuffer.position().
-    final int arraySize = PAGE_SIZE * (dataList.size() - 1) + lastBuf.position();
+    final int arraySize = pageSize * (dataList.size() - 1) + lastBuf.position();
     final byte[] byteArray = new byte[arraySize];
     int start = 0;
     int byteToWrite;

--- a/common/src/main/java/org/apache/nemo/common/DirectByteBufferOutputStream.java
+++ b/common/src/main/java/org/apache/nemo/common/DirectByteBufferOutputStream.java
@@ -56,6 +56,7 @@ public final class DirectByteBufferOutputStream extends OutputStream {
     }
     this.pageSize = size;
     newLastBuffer();
+    currentBuf = dataList.getLast();
   }
 
   /**
@@ -72,7 +73,6 @@ public final class DirectByteBufferOutputStream extends OutputStream {
    */
   @Override
   public void write(final int b) {
-    currentBuf = dataList.getLast();
     if (currentBuf.remaining() <= 0) {
       newLastBuffer();
       currentBuf = dataList.getLast();
@@ -102,7 +102,6 @@ public final class DirectByteBufferOutputStream extends OutputStream {
   public void write(final byte[] b, final int off, final int len) {
     int byteToWrite = len;
     int offset = off;
-    currentBuf = dataList.getLast();
     while (byteToWrite > 0) {
       if (currentBuf.remaining() <= 0) {
         newLastBuffer();

--- a/common/src/main/java/org/apache/nemo/common/DirectByteBufferOutputStream.java
+++ b/common/src/main/java/org/apache/nemo/common/DirectByteBufferOutputStream.java
@@ -163,7 +163,7 @@ public final class DirectByteBufferOutputStream extends OutputStream {
    *
    * @return the {@code LinkedList} of {@code ByteBuffer}s.
    */
-  public List<ByteBuffer> getBufferList() {
+  public List<ByteBuffer> getBufferListAndClear() {
     List<ByteBuffer> result = dataList;
     dataList = new LinkedList<>();
     for (final ByteBuffer buffer : result) {

--- a/common/src/main/java/org/apache/nemo/common/DirectByteBufferOutputStream.java
+++ b/common/src/main/java/org/apache/nemo/common/DirectByteBufferOutputStream.java
@@ -142,7 +142,7 @@ public class DirectByteBufferOutputStream extends OutputStream {
     for(ByteBuffer temp : dataList) {
       // ByteBuffer has to be shifted to read mode by calling ByteBuffer.flip(),
       // which sets its limit to the current position and sets the position to 0.
-      // Note that capacity remains the same.
+      // Note that capacity remains unchanged.
       temp.flip();
       byteToWrite = temp.remaining();
       temp.get(byteArray, start, byteToWrite);

--- a/common/src/main/java/org/apache/nemo/common/DirectByteBufferOutputStream.java
+++ b/common/src/main/java/org/apache/nemo/common/DirectByteBufferOutputStream.java
@@ -43,13 +43,13 @@ public class DirectByteBufferOutputStream extends OutputStream {
   /**
    * Constructor specifying the {@code pageSize}.
    *
-   * @param pageSize should be a power of 2 and greater than 4KB.
+   * @param size should be a power of 2 and greater than 4KB.
    */
-  public DirectByteBufferOutputStream(final int pageSize) {
-    if (pageSize < 4096 || (pageSize & (pageSize - 1)) != 0) {
+  public DirectByteBufferOutputStream(final int size) {
+    if (size < 4096 || (size & (size - 1)) != 0) {
       throw new IllegalArgumentException("Invalid pageSize");
     }
-    this.pageSize = pageSize;
+    pageSize = size;
   }
 
   /**
@@ -109,8 +109,7 @@ public class DirectByteBufferOutputStream extends OutputStream {
         currentBuf.put(b, offset, bufRemaining);
         offset += bufRemaining;
         byteToWrite -= bufRemaining;
-      }
-      else {
+      } else {
         currentBuf.put(b, offset, byteToWrite);
         offset += byteToWrite;
         byteToWrite = 0;

--- a/common/src/test/java/org/apache/nemo/common/BBOutputStreamTest.java
+++ b/common/src/test/java/org/apache/nemo/common/BBOutputStreamTest.java
@@ -26,10 +26,9 @@ import static org.junit.Assert.assertEquals;
 
 /**
  * Tests {@link DirectByteBufferOutputStream}.
- * This class tests basic operations of OutputStream
  */
 public class BBOutputStreamTest {
-  DirectByteBufferOutputStream outputStream;
+  private DirectByteBufferOutputStream outputStream;
 
   @Before
   public void setup(){
@@ -37,7 +36,10 @@ public class BBOutputStreamTest {
   }
 
   @Test
-  public void testIntWrite() {
+  public void testSingleWrite() {
+    int value = 1;
+    outputStream.write(value);
+    assertEquals(value, 1);
   }
 
   @Test
@@ -61,7 +63,7 @@ public class BBOutputStreamTest {
   public void testReRead() {
     String value = "value";
     outputStream.write(value.getBytes());
-    assertEquals("value", new String(outputStream.toByteArray()));
+    assertEquals(value, new String(outputStream.toByteArray()));
     assertEquals(value, new String(outputStream.toByteArray()));
   }
 

--- a/common/src/test/java/org/apache/nemo/common/BBOutputStreamTest.java
+++ b/common/src/test/java/org/apache/nemo/common/BBOutputStreamTest.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.nemo.common;
+
+import org.apache.commons.lang.RandomStringUtils;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests {@link DirectByteBufferOutputStream}.
+ * This class tests basic operations of OutputStream
+ */
+public class BBOutputStreamTest {
+  DirectByteBufferOutputStream outputStream;
+
+  @Before
+  public void setup(){
+    outputStream = new DirectByteBufferOutputStream();
+  }
+
+  @Test
+  public void testIntWrite() {
+  }
+
+  @Test
+  public void testWrite(){
+    String value = "value";
+    outputStream.write(value.getBytes());
+    assertEquals(value, new String(outputStream.toByteArray()));
+  }
+
+  @Test
+  public void testReWrite() {
+    String value1 = "value1";
+    String value2 = "value2";
+    outputStream.write(value1.getBytes());
+    assertEquals(value1, new String(outputStream.toByteArray()));
+    outputStream.write(value2.getBytes());
+    assertEquals(value1+value2, new String(outputStream.toByteArray()));
+  }
+
+  @Test
+  public void testReRead() {
+    String value = "value";
+    outputStream.write(value.getBytes());
+    assertEquals("value", new String(outputStream.toByteArray()));
+    assertEquals(value, new String(outputStream.toByteArray()));
+  }
+
+  @Test
+  public void testLongWrite() {
+    String value = RandomStringUtils.randomAlphanumeric(10000);
+    outputStream.write(value.getBytes());
+    assertEquals(value,new String(outputStream.toByteArray()));
+  }
+
+  @Test
+  public void testLongReWrite() {
+    String value1 = RandomStringUtils.randomAlphanumeric(10000);
+    String value2 = RandomStringUtils.randomAlphanumeric(5000);
+    outputStream.write(value1.getBytes());
+    assertEquals(value1, new String(outputStream.toByteArray()));
+    outputStream.write(value2.getBytes());
+    assertEquals(value1+value2, new String(outputStream.toByteArray()));
+  }
+
+  @Test
+  public void testLongReRead() {
+    String value = RandomStringUtils.randomAlphanumeric(10000);
+    outputStream.write(value.getBytes());
+    assertEquals(value, new String(outputStream.toByteArray()));
+    assertEquals(value, new String(outputStream.toByteArray()));
+  }
+}

--- a/common/src/test/java/org/apache/nemo/common/BBOutputStreamTest.java
+++ b/common/src/test/java/org/apache/nemo/common/BBOutputStreamTest.java
@@ -39,7 +39,7 @@ public class BBOutputStreamTest {
   public void testSingleWrite() {
     int value = 1;
     outputStream.write(value);
-    assertEquals(value, 1);
+    assertEquals(value, outputStream.toByteArray()[0]);
   }
 
   @Test

--- a/common/src/test/java/org/apache/nemo/common/DirectByteBufferOutputStreamTest.java
+++ b/common/src/test/java/org/apache/nemo/common/DirectByteBufferOutputStreamTest.java
@@ -101,7 +101,7 @@ public class DirectByteBufferOutputStreamTest {
     String value = RandomStringUtils.randomAlphanumeric(10000);
     outputStream.write(value.getBytes());
     byte[] totalOutput = outputStream.toByteArray();
-    List<ByteBuffer> bufList = outputStream.getBufferList();
+    List<ByteBuffer> bufList = outputStream.getBufferListAndClear();
     int offset = 0;
     int byteToRead;
     for (final ByteBuffer temp : bufList) {

--- a/common/src/test/java/org/apache/nemo/common/DirectByteBufferOutputStreamTest.java
+++ b/common/src/test/java/org/apache/nemo/common/DirectByteBufferOutputStreamTest.java
@@ -22,12 +22,16 @@ import org.apache.commons.lang.RandomStringUtils;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.List;
+
 import static org.junit.Assert.assertEquals;
 
 /**
  * Tests {@link DirectByteBufferOutputStream}.
  */
-public class BBOutputStreamTest {
+public class DirectByteBufferOutputStreamTest {
   private DirectByteBufferOutputStream outputStream;
 
   @Before
@@ -90,5 +94,23 @@ public class BBOutputStreamTest {
     outputStream.write(value.getBytes());
     assertEquals(value, new String(outputStream.toByteArray()));
     assertEquals(value, new String(outputStream.toByteArray()));
+  }
+
+  @Test
+  public void testGetBufferList() {
+    String value = RandomStringUtils.randomAlphanumeric(10000);
+    outputStream.write(value.getBytes());
+    byte[] totalOutput = outputStream.toByteArray();
+    List<ByteBuffer> bufList = outputStream.getBufferList();
+    int offset = 0;
+    int byteToRead;
+    for (final ByteBuffer temp : bufList) {
+      byteToRead = temp.remaining();
+      byte[] output = new byte[byteToRead];
+      temp.get(output, 0, byteToRead);
+      byte[] expected = Arrays.copyOfRange(totalOutput, offset, offset+byteToRead);
+      assertEquals(new String(expected), new String(output));
+      offset += byteToRead;
+    }
   }
 }


### PR DESCRIPTION
JIRA: [NEMO-383: Implement DirectByteBufferOutputStream for Off-heap SerializedMemoryStore](https://issues.apache.org/jira/projects/NEMO/issues/NEMO-383)

**Major changes:**
- Added `DirectByteBufferOuputStream` for writing data off-heap.

**Tests for the changes:**
- Added `DirectByteBufferOutputStreamTest` to test proper write using the `DirectByteBufferOutputStream`.
