### PR TITLE
[NEMO-391] Set GrpcMessageEnvironment as a default implementation

### DIFF
--- a/runtime/common/src/main/java/org/apache/nemo/runtime/common/message/MessageEnvironment.java
+++ b/runtime/common/src/main/java/org/apache/nemo/runtime/common/message/MessageEnvironment.java
@@ -19,7 +19,6 @@
 package org.apache.nemo.runtime.common.message;
 
 import org.apache.nemo.runtime.common.message.grpc.GrpcMessageEnvironment;
-import org.apache.nemo.runtime.common.message.ncs.NcsMessageEnvironment;
 import org.apache.reef.tang.annotations.DefaultImplementation;
 
 import java.util.concurrent.Future;

--- a/runtime/common/src/main/java/org/apache/nemo/runtime/common/message/MessageEnvironment.java
+++ b/runtime/common/src/main/java/org/apache/nemo/runtime/common/message/MessageEnvironment.java
@@ -18,6 +18,7 @@
  */
 package org.apache.nemo.runtime.common.message;
 
+import org.apache.nemo.runtime.common.message.grpc.GrpcMessageEnvironment;
 import org.apache.nemo.runtime.common.message.ncs.NcsMessageEnvironment;
 import org.apache.reef.tang.annotations.DefaultImplementation;
 
@@ -27,7 +28,7 @@ import java.util.concurrent.Future;
  * Set up {@link MessageListener}s to handle incoming messages on this node, and connect to remote nodes and return
  * {@link MessageSender}s to send message to them.
  */
-@DefaultImplementation(NcsMessageEnvironment.class)
+@DefaultImplementation(GrpcMessageEnvironment.class)
 public interface MessageEnvironment {
 
   // The ID of the master used for distinguish the sender or receiver.


### PR DESCRIPTION
JIRA: [NEMO-391: Set GrpcMessageEnvironment as a default implementation](https://issues.apache.org/jira/projects/NEMO/issues/NEMO-391)

**Major changes:**
- Change the default implementation of MessageEnvironment to GrpcMessageEnvironment

