### PR TITLE
[NEMO-402] Fix guava version conflict

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@ under the License.
     <hadoop.version>2.7.2</hadoop.version>
     <log4j.configuration>file://log4j.properties</log4j.configuration>
     <netty.version>4.1.16.Final</netty.version>
-    <guava.version>19.0</guava.version>
+    <guava.version>20.0</guava.version>
     <grpc.version>1.7.0</grpc.version>
     <jackson.version>2.8.8</jackson.version>
     <netlib.version>1.1.2</netlib.version>


### PR DESCRIPTION
JIRA: [NEMO-402: Broken guava version conflicts cause ERROR: Trying to remove a RunningJob that is unknown ](https://issues.apache.org/jira/projects/NEMO/issues/NEMO-###)

**Major changes:**
- guava version 19.0 -> 20.0

Please refer to JIRA description for the bug report details. 