### PR TITLE
[NEMO-412] Address Sonar Cloud issue for MemoryChunk

### DIFF
--- a/runtime/executor/src/main/java/org/apache/nemo/runtime/executor/data/MemoryChunk.java
+++ b/runtime/executor/src/main/java/org/apache/nemo/runtime/executor/data/MemoryChunk.java
@@ -117,7 +117,7 @@ public class MemoryChunk {
   @SuppressWarnings("restriction")
   public final byte get(final int index) {
     final long pos = address + index;
-    if (checkIndex(index, pos, 0)) {
+    if (checkIndex(index, pos, 1)) {
       return UNSAFE.getByte(pos);
     } else if (address > addressLimit) {
       throw new IllegalStateException("MemoryChunk has been freed");
@@ -135,7 +135,7 @@ public class MemoryChunk {
   @SuppressWarnings("restriction")
   public final void put(final int index, final byte b) {
     final long pos = address + index;
-    if (checkIndex(index, pos, 0)) {
+    if (checkIndex(index, pos, 1)) {
       UNSAFE.putByte(pos, b);
     } else if (address > addressLimit) {
       throw new IllegalStateException("MemoryChunk has been freed");
@@ -451,12 +451,8 @@ public class MemoryChunk {
     putLong(index, Double.doubleToRawLongBits(value));
   }
 
-  private boolean checkIndex(final int index, final long pos, final int typeSize) throws IndexOutOfBoundsException {
-    if (!(index >= 0 && pos <= addressLimit - typeSize)) {
-      throw new IndexOutOfBoundsException();
-    } else {
-      return true;
-    }
+  private boolean checkIndex(final int index, final long pos, final int typeSize) {
+    return (index >= 0 && pos <= (addressLimit - typeSize));
   }
 
   @SuppressWarnings("restriction")

--- a/runtime/executor/src/main/java/org/apache/nemo/runtime/executor/data/MemoryChunk.java
+++ b/runtime/executor/src/main/java/org/apache/nemo/runtime/executor/data/MemoryChunk.java
@@ -117,7 +117,7 @@ public class MemoryChunk {
   @SuppressWarnings("restriction")
   public final byte get(final int index) {
     final long pos = address + index;
-    if (checkIndex(index, pos, 1)) {
+    if (checkIndex(index, pos, 0)) {
       return UNSAFE.getByte(pos);
     } else if (address > addressLimit) {
       throw new IllegalStateException("MemoryChunk has been freed");
@@ -135,7 +135,7 @@ public class MemoryChunk {
   @SuppressWarnings("restriction")
   public final void put(final int index, final byte b) {
     final long pos = address + index;
-    if (checkIndex(index, pos, 1)) {
+    if (checkIndex(index, pos, 0)) {
       UNSAFE.putByte(pos, b);
     } else if (address > addressLimit) {
       throw new IllegalStateException("MemoryChunk has been freed");


### PR DESCRIPTION
JIRA: [NEMO-412: Address Sonar Cloud issue for MemoryChunk](https://issues.apache.org/jira/projects/NEMO/issues/NEMO-412)

**Major changes:**
- `checkIndex()` in `MemoryChunk` is fixed to return either true or false.

**Minor changes to note:**
- type length for byte access using UNSAFE when calling `checkIndex()` changed to 1.
