### PR TITLE
[NEMO-413] Fix index checking for byte access of MemoryChunk using UNSAFE

### DIFF
--- a/runtime/executor/src/main/java/org/apache/nemo/runtime/executor/data/MemoryChunk.java
+++ b/runtime/executor/src/main/java/org/apache/nemo/runtime/executor/data/MemoryChunk.java
@@ -38,6 +38,7 @@ public class MemoryChunk {
   @SuppressWarnings("restriction")
   protected static final long BYTE_ARRAY_BASE_OFFSET = UNSAFE.arrayBaseOffset(byte[].class);
   private static final boolean LITTLE_ENDIAN = (ByteOrder.nativeOrder() == ByteOrder.LITTLE_ENDIAN);
+  private static final int BYTE_SIZE = 1;
   private static final int SHORT_SIZE = 2;
   private static final int CHAR_SIZE = 2;
   private static final int INT_SIZE = 4;
@@ -117,7 +118,7 @@ public class MemoryChunk {
   @SuppressWarnings("restriction")
   public final byte get(final int index) {
     final long pos = address + index;
-    if (checkIndex(index, pos, 0)) {
+    if (checkIndex(index, pos, BYTE_SIZE)) {
       return UNSAFE.getByte(pos);
     } else if (address > addressLimit) {
       throw new IllegalStateException("MemoryChunk has been freed");
@@ -135,7 +136,7 @@ public class MemoryChunk {
   @SuppressWarnings("restriction")
   public final void put(final int index, final byte b) {
     final long pos = address + index;
-    if (checkIndex(index, pos, 0)) {
+    if (checkIndex(index, pos, BYTE_SIZE)) {
       UNSAFE.putByte(pos, b);
     } else if (address > addressLimit) {
       throw new IllegalStateException("MemoryChunk has been freed");


### PR DESCRIPTION
JIRA: [NEMO-413: Fix index checking for byte access of MemoryChunk using UNSAFE](https://issues.apache.org/jira/projects/NEMO/issues/NEMO-413)

**Major changes:**
- Index checking for byte operation using UNSAFE fixed: type size for byte changed from 0 to 1.
