### PR TITLE
[NEMO-414] Command-line specified runtime data plane configurations not applied

### DIFF
--- a/client/src/main/java/org/apache/nemo/client/JobLauncher.java
+++ b/client/src/main/java/org/apache/nemo/client/JobLauncher.java
@@ -416,6 +416,7 @@ public final class JobLauncher {
     cl.registerShortNameOfClass(JobConf.PartitionTransportClientNumThreads.class);
     cl.registerShortNameOfClass(JobConf.MaxNumDownloadsForARuntimeEdge.class);
     cl.registerShortNameOfClass(JobConf.SchedulerImplClassName.class);
+    cl.registerShortNameOfClass(JobConf.ScheduleSerThread.class);
     cl.registerShortNameOfClass(JobConf.MaxOffheapMb.class);
     cl.registerShortNameOfClass(JobConf.ChunkSizeKb.class);
     cl.processCommandLine(args);

--- a/conf/src/main/java/org/apache/nemo/conf/DataPlaneConf.java
+++ b/conf/src/main/java/org/apache/nemo/conf/DataPlaneConf.java
@@ -24,6 +24,9 @@ import org.apache.reef.tang.annotations.Parameter;
 
 import javax.inject.Inject;
 
+/**
+ * Data plane Configuration for Executors.
+ */
 public final class DataPlaneConf {
 
   private final int numIOThreads;
@@ -44,7 +47,6 @@ public final class DataPlaneConf {
                         @Parameter(JobConf.PartitionTransportServerBacklog.class) final int serverBackLog,
                         @Parameter(JobConf.PartitionTransportServerNumListeningThreads.class) final int listenThreads,
                         @Parameter(JobConf.PartitionTransportServerNumWorkingThreads.class) final int workThreads) {
-
     this.numIOThreads = numIOThreads;
     this.maxNumDownloads = maxNumDownloads;
     this.scheduleSerThread = scheduleSerThread;

--- a/conf/src/main/java/org/apache/nemo/conf/DataPlaneConf.java
+++ b/conf/src/main/java/org/apache/nemo/conf/DataPlaneConf.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.nemo.conf;
+
+import org.apache.reef.tang.Configuration;
+import org.apache.reef.tang.Tang;
+import org.apache.reef.tang.annotations.Parameter;
+
+import javax.inject.Inject;
+
+public final class DataPlaneConf {
+
+  private final int numIOThreads;
+  private final int maxNumDownloads;
+  private final int scheduleSerThread;
+  private final int serverPort;
+  private final int clientNumThreads;
+  private final int serverBackLog;
+  private final int listenThreads;
+  private final int workThreads;
+
+  @Inject
+  private DataPlaneConf(@Parameter(JobConf.IORequestHandleThreadsTotal.class) final int numIOThreads,
+                        @Parameter(JobConf.MaxNumDownloadsForARuntimeEdge.class) final int maxNumDownloads,
+                        @Parameter(JobConf.ScheduleSerThread.class) final int scheduleSerThread,
+                        @Parameter(JobConf.PartitionTransportServerPort.class) final int serverPort,
+                        @Parameter(JobConf.PartitionTransportClientNumThreads.class) final int clientNumThreads,
+                        @Parameter(JobConf.PartitionTransportServerBacklog.class) final int serverBackLog,
+                        @Parameter(JobConf.PartitionTransportServerNumListeningThreads.class) final int listenThreads,
+                        @Parameter(JobConf.PartitionTransportServerNumWorkingThreads.class) final int workThreads) {
+
+    this.numIOThreads = numIOThreads;
+    this.maxNumDownloads = maxNumDownloads;
+    this.scheduleSerThread = scheduleSerThread;
+    this.serverPort = serverPort;
+    this.clientNumThreads = clientNumThreads;
+    this.serverBackLog = serverBackLog;
+    this.listenThreads = listenThreads;
+    this.workThreads = workThreads;
+  }
+
+  public Configuration getDataPlaneConfiguration() {
+    return Tang.Factory.getTang().newConfigurationBuilder()
+      .bindNamedParameter(JobConf.IORequestHandleThreadsTotal.class, Integer.toString(numIOThreads))
+      .bindNamedParameter(JobConf.MaxNumDownloadsForARuntimeEdge.class, Integer.toString(maxNumDownloads))
+      .bindNamedParameter(JobConf.ScheduleSerThread.class, Integer.toString(scheduleSerThread))
+      .bindNamedParameter(JobConf.PartitionTransportServerPort.class, Integer.toString(serverPort))
+      .bindNamedParameter(JobConf.PartitionTransportClientNumThreads.class, Integer.toString(clientNumThreads))
+      .bindNamedParameter(JobConf.PartitionTransportServerBacklog.class, Integer.toString(serverBackLog))
+      .bindNamedParameter(JobConf.PartitionTransportServerNumListeningThreads.class, Integer.toString(listenThreads))
+      .bindNamedParameter(JobConf.PartitionTransportServerNumWorkingThreads.class, Integer.toString(workThreads))
+      .build();
+  }
+ }


### PR DESCRIPTION
JIRA: [NEMO-414: Command-line specified runtime data plane configurations not applied](https://issues.apache.org/jira/projects/NEMO/issues/NEMO-414)

**Major changes:**
- User-specified data plane configuration now applies to parameters.

**Minor changes to note:**
- The number of serialization threads for scheduling(schedule_ser_thread) now can be set through the command-line argument.

