### PR TITLE
[Nemo-440] Update README.md about java 11 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Please refer to the [Contribution guideline](.github/CONTRIBUTING.md) to contrib
 ## Nemo prerequisites and setup
 
 ### Prerequisites
-* Java 8 or later (tested on Java 8 and Java 11)
+* Java 11
 * Maven
 * YARN settings
     * Download Hadoop 2.7.2 at https://archive.apache.org/dist/hadoop/common/hadoop-2.7.2/


### PR DESCRIPTION
JIRA: [NEMO-440: Migrate to Java11 and use Java 11 Features](https://issues.apache.org/jira/projects/NEMO/issues/NEMO-440)

**Major changes:**

- Update readme

**Minor changes to note:**
- None

**Tests for the changes:**
- None

**Other comments:**
- Java 11 support has been done in PR #291
- Nemo build fails with Java 8 due to the pom configuration that does not work with Java 8
