### PR TITLE
[MINOR] Fix Travis CI + Bring back support for Java 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ dist: trusty
 # For maven builds
 language: java
 jdk:
+  - oraclejdk8
   - oraclejdk11
   - openjdk11
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,6 @@ env:
   jobs:
     - GOAL="verify -B -q -ff -Dsurefire.useFile=false -Dorg.slf4j.simpleLogger.defaultLogLevel=info"
 before_install:
-#  - sudo apt update && sudo apt install -y libgif-dev
   - nvm install node  # for Web UI build
 install: true
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ env:
   jobs:
     - GOAL="verify -B -q -ff -Dsurefire.useFile=false -Dorg.slf4j.simpleLogger.defaultLogLevel=info"
 before_install:
-  - sudo apt update && sudo apt install -y libgif-dev
+#  - sudo apt update && sudo apt install -y libgif-dev
   - nvm install node  # for Web UI build
 install: true
 script:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Please refer to the [Contribution guideline](.github/CONTRIBUTING.md) to contrib
 ## Nemo prerequisites and setup
 
 ### Prerequisites
-* Java 11
+* Java 8 or later (tested on Java 8 and Java 11)
 * Maven
 * YARN settings
     * Download Hadoop 2.7.2 at https://archive.apache.org/dist/hadoop/common/hadoop-2.7.2/

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@ under the License.
   </scm>
 
   <properties>
-    <java.version>11</java.version>
+    <java.version>1.8</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <maven.compiler.version>3.8.1</maven.compiler.version>
@@ -176,9 +176,10 @@ under the License.
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
           <version>${maven.compiler.version}</version>
-          <configuration>
-            <release>${java.version}</release>
-          </configuration>
+          <!-- Uncomment when dropping support for Java 8 -->
+          <!--<configuration>-->
+          <!--  <release>${java.version}</release>-->
+          <!--</configuration>-->
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
**Major changes:**
- Fixes Travis CI script that have been failing due to gpg error
- Bring back support for Java 8, as Hadoop and REEF still needs support for Java 8 (reverts #291)

**Minor changes to note:**
- None

**Tests for the changes:**
- N/A

**Other comments:**
- None

Closes #296 
