### PR TITLE
[WIP] Avoid yarn conflict + Save Metrics after waiting to get full data

### DIFF
--- a/bin/run_beam.sh
+++ b/bin/run_beam.sh
@@ -21,4 +21,4 @@ VERSION=$(mvn -q \
   -Dexec.executable=echo -Dexec.args='${project.version}' \
   --non-recursive exec:exec)
 
-java -Dlog4j.configuration=file://`pwd`/log4j.properties -cp examples/beam/target/nemo-examples-beam-${VERSION}-shaded.jar:client/target/nemo-client-${VERSION}-shaded.jar:`yarn classpath` org.apache.nemo.client.JobLauncher "$@"
+java -Dlog4j.configuration=file://`pwd`/log4j.properties -cp examples/beam/target/nemo-examples-beam-${VERSION}-shaded.jar:client/target/nemo-client-${VERSION}-shaded.jar:`$YARN_HOME/bin/yarn classpath` org.apache.nemo.client.JobLauncher "$@"

--- a/runtime/master/src/main/java/org/apache/nemo/runtime/master/RuntimeMaster.java
+++ b/runtime/master/src/main/java/org/apache/nemo/runtime/master/RuntimeMaster.java
@@ -221,9 +221,17 @@ public final class RuntimeMaster {
   public void flushMetrics() {
     // send metric flush request to all executors
     metricManagerMaster.sendMetricFlushRequest();
+  }
 
+  /**
+   * Save metrics.
+   */
+  public void saveMetrics() {
+    // send metric to local file
     metricStore.dumpAllMetricToFile(Paths.get(dagDirectory,
       "Metric_" + jobId + "_" + System.currentTimeMillis() + ".json").toString());
+
+    // send metric to database
     if (this.dbEnabled) {
       metricStore.saveOptimizationMetricsToDB(dbAddress, jobId, dbId, dbPassword);
     }
@@ -273,6 +281,8 @@ public final class RuntimeMaster {
       // clean up state...
       Thread.currentThread().interrupt();
     }
+
+    saveMetrics();
 
     runtimeMasterThread.execute(() -> {
       scheduler.terminate();

--- a/runtime/master/src/main/java/org/apache/nemo/runtime/master/RuntimeMaster.java
+++ b/runtime/master/src/main/java/org/apache/nemo/runtime/master/RuntimeMaster.java
@@ -285,8 +285,6 @@ public final class RuntimeMaster {
     // No need to speculate anymore
     speculativeTaskCloningThread.shutdown();
 
-    flushMetrics();
-
     try {
       // wait for metric flush
       if (!metricCountDownLatch.await(METRIC_ARRIVE_TIMEOUT, TimeUnit.MILLISECONDS)) {

--- a/runtime/master/src/main/java/org/apache/nemo/runtime/master/metric/MetricStore.java
+++ b/runtime/master/src/main/java/org/apache/nemo/runtime/master/metric/MetricStore.java
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.BufferedWriter;
 import java.io.ByteArrayOutputStream;
+import java.io.FileNotFoundException;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
@@ -245,6 +246,8 @@ public final class MetricStore {
     try (BufferedWriter writer = new BufferedWriter(new FileWriter(filePath))) {
       final String jsonDump = dumpAllMetricToJson();
       writer.write(jsonDump);
+    } catch (final FileNotFoundException e) {
+      LOG.warn("fail to write metric to local file: {}", e);
     } catch (final IOException e) {
       throw new MetricException(e);
     }


### PR DESCRIPTION
**Major changes:**
-

**Minor changes to note:**
- Change yarn command in run_beam.sh file to avoid conflict with javascript package manager
- Split metric saving part from flushMetric function and call metric saving part after waiting metric flush

**Tests for the changes:**
- 

**Other comments:**
- 

Closes #GITHUB_PR_NUMBER
