### PR TITLE
[MINOR] Avoid yarn conflict + Save Metrics after waiting to get full data 

### DIFF
--- a/bin/run_beam.sh
+++ b/bin/run_beam.sh
@@ -21,4 +21,4 @@ VERSION=$(mvn -q \
   -Dexec.executable=echo -Dexec.args='${project.version}' \
   --non-recursive exec:exec)
 
-java -Dlog4j.configuration=file://`pwd`/log4j.properties -cp examples/beam/target/nemo-examples-beam-${VERSION}-shaded.jar:client/target/nemo-client-${VERSION}-shaded.jar:`yarn classpath` org.apache.nemo.client.JobLauncher "$@"
+java -Dlog4j.configuration=file://`pwd`/log4j.properties -cp examples/beam/target/nemo-examples-beam-${VERSION}-shaded.jar:client/target/nemo-client-${VERSION}-shaded.jar:`$YARN_HOME/bin/yarn classpath` org.apache.nemo.client.JobLauncher "$@"

--- a/runtime/driver/src/main/java/org/apache/nemo/driver/NemoDriver.java
+++ b/runtime/driver/src/main/java/org/apache/nemo/driver/NemoDriver.java
@@ -142,7 +142,10 @@ public final class NemoDriver {
    */
   private void shutdown() {
     LOG.info("Driver shutdown initiated");
-    runnerThread.execute(runtimeMaster::terminate);
+    runnerThread.execute(() -> {
+      runtimeMaster.saveMetrics();
+      runtimeMaster.terminate();
+    });
     runnerThread.shutdown();
   }
 

--- a/runtime/driver/src/main/java/org/apache/nemo/driver/NemoDriver.java
+++ b/runtime/driver/src/main/java/org/apache/nemo/driver/NemoDriver.java
@@ -142,10 +142,7 @@ public final class NemoDriver {
    */
   private void shutdown() {
     LOG.info("Driver shutdown initiated");
-    runnerThread.execute(() -> {
-      runtimeMaster.saveMetrics();
-      runtimeMaster.terminate();
-    });
+    runnerThread.execute(runtimeMaster::terminate);
     runnerThread.shutdown();
   }
 

--- a/runtime/master/src/main/java/org/apache/nemo/runtime/master/RuntimeMaster.java
+++ b/runtime/master/src/main/java/org/apache/nemo/runtime/master/RuntimeMaster.java
@@ -221,9 +221,17 @@ public final class RuntimeMaster {
   public void flushMetrics() {
     // send metric flush request to all executors
     metricManagerMaster.sendMetricFlushRequest();
+  }
 
+  /**
+   * Save metrics.
+   */
+  public void saveMetrics() {
+    // send metric to local file
     metricStore.dumpAllMetricToFile(Paths.get(dagDirectory,
       "Metric_" + jobId + "_" + System.currentTimeMillis() + ".json").toString());
+
+    // send metric to database
     if (this.dbEnabled) {
       metricStore.saveOptimizationMetricsToDB(dbAddress, jobId, dbId, dbPassword);
     }
@@ -273,6 +281,8 @@ public final class RuntimeMaster {
       // clean up state...
       Thread.currentThread().interrupt();
     }
+
+    saveMetrics();
 
     runtimeMasterThread.execute(() -> {
       scheduler.terminate();

--- a/runtime/master/src/main/java/org/apache/nemo/runtime/master/RuntimeMaster.java
+++ b/runtime/master/src/main/java/org/apache/nemo/runtime/master/RuntimeMaster.java
@@ -41,6 +41,7 @@ import org.apache.nemo.runtime.master.metric.MetricStore;
 import org.apache.nemo.runtime.master.resource.ContainerManager;
 import org.apache.nemo.runtime.master.resource.ExecutorRepresenter;
 import org.apache.nemo.runtime.master.scheduler.BatchScheduler;
+import org.apache.nemo.runtime.master.scheduler.ExecutorRegistry;
 import org.apache.nemo.runtime.master.scheduler.Scheduler;
 import org.apache.nemo.runtime.master.servlet.*;
 import org.apache.reef.annotations.audience.DriverSide;
@@ -90,6 +91,7 @@ public final class RuntimeMaster {
 
   private final Scheduler scheduler;
   private final ContainerManager containerManager;
+  private final ExecutorRegistry executorRegistry;
   private final MetricMessageHandler metricMessageHandler;
   private final MessageEnvironment masterMessageEnvironment;
   private final ClientRPC clientRPC;
@@ -130,6 +132,7 @@ public final class RuntimeMaster {
   @Inject
   private RuntimeMaster(final Scheduler scheduler,
                         final ContainerManager containerManager,
+                        final ExecutorRegistry executorRegistry,
                         final MetricMessageHandler metricMessageHandler,
                         final MessageEnvironment masterMessageEnvironment,
                         final MetricManagerMaster metricManagerMaster,
@@ -159,6 +162,7 @@ public final class RuntimeMaster {
 
     this.scheduler = scheduler;
     this.containerManager = containerManager;
+    this.executorRegistry = executorRegistry;
     this.metricMessageHandler = metricMessageHandler;
     this.masterMessageEnvironment = masterMessageEnvironment;
     this.masterMessageEnvironment
@@ -221,7 +225,7 @@ public final class RuntimeMaster {
    */
   public void flushMetrics() {
     if (metricCountDownLatch.getCount() == 0) {
-      metricCountDownLatch = new CountDownLatch(resourceRequestCount.get());
+      metricCountDownLatch = new CountDownLatch(executorRegistry.getNumberOfRunningExecutors());
       // send metric flush request to all executors
       metricManagerMaster.sendMetricFlushRequest();
     }

--- a/runtime/master/src/main/java/org/apache/nemo/runtime/master/RuntimeMaster.java
+++ b/runtime/master/src/main/java/org/apache/nemo/runtime/master/RuntimeMaster.java
@@ -300,8 +300,6 @@ public final class RuntimeMaster {
       Thread.currentThread().interrupt();
     }
 
-    saveMetrics();
-
     runtimeMasterThread.execute(() -> {
       scheduler.terminate();
       try {

--- a/runtime/master/src/main/java/org/apache/nemo/runtime/master/RuntimeMaster.java
+++ b/runtime/master/src/main/java/org/apache/nemo/runtime/master/RuntimeMaster.java
@@ -285,8 +285,6 @@ public final class RuntimeMaster {
     // No need to speculate anymore
     speculativeTaskCloningThread.shutdown();
 
-    flushMetrics();
-
     try {
       // wait for metric flush
       if (!metricCountDownLatch.await(METRIC_ARRIVE_TIMEOUT, TimeUnit.MILLISECONDS)) {

--- a/runtime/master/src/main/java/org/apache/nemo/runtime/master/RuntimeMaster.java
+++ b/runtime/master/src/main/java/org/apache/nemo/runtime/master/RuntimeMaster.java
@@ -229,12 +229,7 @@ public final class RuntimeMaster {
       // send metric flush request to all executors
       metricManagerMaster.sendMetricFlushRequest();
     }
-  }
 
-  /**
-   * Save metrics.
-   */
-  public void saveMetrics() {
     try {
       if (!metricCountDownLatch.await(METRIC_ARRIVE_TIMEOUT, TimeUnit.MILLISECONDS)) {
         LOG.warn("Write Metric before all metric messages arrived.");
@@ -506,7 +501,6 @@ public final class RuntimeMaster {
     dagLoggingExecutor.scheduleAtFixedRate(new Runnable() {
       public void run() {
         flushMetrics();
-        saveMetrics();
         planStateManager.storeJSON("periodic");
       }
     }, DAG_LOGGING_PERIOD, DAG_LOGGING_PERIOD, TimeUnit.MILLISECONDS);

--- a/runtime/master/src/main/java/org/apache/nemo/runtime/master/metric/MetricStore.java
+++ b/runtime/master/src/main/java/org/apache/nemo/runtime/master/metric/MetricStore.java
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.BufferedWriter;
 import java.io.ByteArrayOutputStream;
+import java.io.FileNotFoundException;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
@@ -245,6 +246,8 @@ public final class MetricStore {
     try (BufferedWriter writer = new BufferedWriter(new FileWriter(filePath))) {
       final String jsonDump = dumpAllMetricToJson();
       writer.write(jsonDump);
+    } catch (final FileNotFoundException e) {
+      LOG.warn("fail to write metric to local file: {}", e);
     } catch (final IOException e) {
       throw new MetricException(e);
     }

--- a/runtime/master/src/main/java/org/apache/nemo/runtime/master/metric/MetricStore.java
+++ b/runtime/master/src/main/java/org/apache/nemo/runtime/master/metric/MetricStore.java
@@ -247,7 +247,7 @@ public final class MetricStore {
       final String jsonDump = dumpAllMetricToJson();
       writer.write(jsonDump);
     } catch (final FileNotFoundException e) {
-      LOG.warn("fail to write metric to local file: {}", e);
+      LOG.warn("Failure while writing metrics to local file: {}", e);
     } catch (final IOException e) {
       throw new MetricException(e);
     }

--- a/runtime/master/src/main/java/org/apache/nemo/runtime/master/scheduler/ExecutorRegistry.java
+++ b/runtime/master/src/main/java/org/apache/nemo/runtime/master/scheduler/ExecutorRegistry.java
@@ -78,6 +78,10 @@ public final class ExecutorRegistry {
     consumer.accept(getRunningExecutors());
   }
 
+  public synchronized int getNumberOfRunningExecutors() {
+    return getRunningExecutors().size();
+  }
+
   synchronized void updateExecutor(
     final String executorId,
     final BiFunction<ExecutorRepresenter, ExecutorState, Pair<ExecutorRepresenter, ExecutorState>> updater) {


### PR DESCRIPTION
**Major changes:**
- 

**Minor changes to note:**
- Change yarn command in run_beam.sh file to avoid conflict with javascript package manager
- Split metric saving part from flushMetric function and call metric saving part after waiting metric flush

**Tests for the changes:**
- 

**Other comments:**
- 

Closes #GITHUB_PR_NUMBER
