### PR TITLE
[NEMO-472] Implement Intermediate Combine

### DIFF
--- a/compiler/frontend/beam/src/main/java/org/apache/nemo/compiler/frontend/beam/PipelineTranslationContext.java
+++ b/compiler/frontend/beam/src/main/java/org/apache/nemo/compiler/frontend/beam/PipelineTranslationContext.java
@@ -277,7 +277,7 @@ final class PipelineTranslationContext {
     }
     // If GBKTransform represents a partial CombinePerKey transformation, we do NOT need to shuffle its input,
     // since its output will be shuffled before going through a final CombinePerKey transformation.
-    if ((dstTransform instanceof GBKTransform && !((GBKTransform) dstTransform).getIsPartialCombining())
+    if ((dstTransform instanceof CombineTransform && !((CombineTransform) dstTransform).getIsPartialCombining())
       || dstTransform instanceof GroupByKeyTransform) {
       return CommunicationPatternProperty.Value.SHUFFLE;
     }

--- a/compiler/frontend/beam/src/main/java/org/apache/nemo/compiler/frontend/beam/transform/CombineTransformFactory.java
+++ b/compiler/frontend/beam/src/main/java/org/apache/nemo/compiler/frontend/beam/transform/CombineTransformFactory.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.nemo.compiler.frontend.beam.transform;
+
+import org.apache.beam.runners.core.SystemReduceFn;
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.transforms.DoFnSchemaInformation;
+import org.apache.beam.sdk.transforms.display.DisplayData;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.TupleTag;
+import org.apache.beam.sdk.values.WindowingStrategy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Factory for the combine transform that combines the results during the group by key.
+ * @param <K> the type of the key.
+ * @param <InputT> the type of the input values.
+ * @param <AccumT> the type of the accumulators.
+ * @param <OutputT> the type of the output.
+ */
+public class CombineTransformFactory<K, InputT, AccumT, OutputT> {
+  private static final Logger LOG = LoggerFactory.getLogger(CombineTransformFactory.class.getName());
+
+  private final SystemReduceFn combineFn;
+  private final SystemReduceFn intermediateCombineFn;
+  private final SystemReduceFn finalReduceFn;
+
+  private final Coder<KV<K, InputT>> inputCoder;
+  private final TupleTag<KV<K, AccumT>> partialMainOutputTag;
+  private final Coder<KV<K, AccumT>> accumulatorCoder;
+  private final Map<TupleTag<?>, Coder<?>> outputCoders;
+
+  private final TupleTag<KV<K, OutputT>> mainOutputTag;
+  private final WindowingStrategy<?, ?> windowingStrategy;
+  private final PipelineOptions options;
+
+  private final DoFnSchemaInformation doFnSchemaInformation;
+  private final DisplayData displayData;
+
+  public CombineTransformFactory(final Coder<KV<K, InputT>> inputCoder,
+                                 final TupleTag<KV<K, AccumT>> partialMainOutputTag,
+                                 final Coder<KV<K, AccumT>> accumulatorCoder,
+                                 final Map<TupleTag<?>, Coder<?>> outputCoders,
+                                 final TupleTag<KV<K, OutputT>> mainOutputTag,
+                                 final WindowingStrategy<?, ?> windowingStrategy,
+                                 final PipelineOptions options,
+                                 final SystemReduceFn combineFn,
+                                 final SystemReduceFn intermediateCombineFn,
+                                 final SystemReduceFn finalReduceFn,
+                                 final DoFnSchemaInformation doFnSchemaInformation,
+                                 final DisplayData displayData) {
+    this.combineFn = combineFn;
+    this.intermediateCombineFn = intermediateCombineFn;
+    this.finalReduceFn = finalReduceFn;
+
+    this.inputCoder = inputCoder;
+    this.partialMainOutputTag = partialMainOutputTag;
+    this.accumulatorCoder = accumulatorCoder;
+    this.outputCoders = outputCoders;
+
+    this.mainOutputTag = mainOutputTag;
+    this.windowingStrategy = windowingStrategy;
+    this.options = options;
+
+    this.doFnSchemaInformation = doFnSchemaInformation;
+    this.displayData = displayData;
+  }
+
+
+  /**
+   * Get the partial combine transform of the combine transform.
+   * @return the partial combine transform for the combine transform.
+   */
+  public CombineTransform<K, InputT, AccumT> getPartialCombineTransform() {
+    return new CombineTransform<>(inputCoder,
+      Collections.singletonMap(partialMainOutputTag, accumulatorCoder),
+      partialMainOutputTag,
+      windowingStrategy,
+      options,
+      combineFn,
+      doFnSchemaInformation,
+      displayData, true);
+  }
+
+  /**
+   * Get the intermediate combine transform of the combine transform.
+   * @return the intermediate combine transform for the combine transform.
+   */
+  public CombineTransform<K, AccumT, AccumT> getIntermediateCombineTransform() {
+    return new CombineTransform<>(accumulatorCoder,
+      Collections.singletonMap(partialMainOutputTag, accumulatorCoder),
+      partialMainOutputTag,
+      windowingStrategy,
+      options,
+      intermediateCombineFn,
+      doFnSchemaInformation,
+      displayData, false);
+  }
+
+  /**
+   * Get the final combine transform of the combine transform.
+   * @return the final combine transform for the combine transform.
+   */
+  public CombineTransform<K, AccumT, OutputT> getFinalCombineTransform() {
+    return new CombineTransform<>(accumulatorCoder,
+      outputCoders,
+      mainOutputTag,
+      windowingStrategy,
+      options,
+      finalReduceFn,
+      doFnSchemaInformation,
+      displayData, false, this.getIntermediateCombineTransform());
+  }
+}

--- a/compiler/frontend/beam/src/main/java/org/apache/nemo/compiler/frontend/beam/transform/IntermediateCombineFn.java
+++ b/compiler/frontend/beam/src/main/java/org/apache/nemo/compiler/frontend/beam/transform/IntermediateCombineFn.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.nemo.compiler.frontend.beam.transform;
+
+import org.apache.beam.sdk.coders.CannotProvideCoderException;
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.CoderRegistry;
+import org.apache.beam.sdk.transforms.Combine;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+
+/**
+ * Wrapper class for {@link Combine.CombineFn}.
+ * When adding input, it merges its accumulator and input accumulator into a single accumulator.
+ * After then, it returns the accumulator for it to be merged later on by the {@link FinalCombineFn}.
+ * @param <AccumT> accumulator type.
+ */
+public final class IntermediateCombineFn<AccumT> extends Combine.CombineFn<AccumT, AccumT, AccumT> {
+  private static final Logger LOG = LoggerFactory.getLogger(IntermediateCombineFn.class.getName());
+  private final Combine.CombineFn<?, AccumT, ?> originFn;
+  private final Coder<AccumT> accumCoder;
+
+  public IntermediateCombineFn(final Combine.CombineFn<?, AccumT, ?> originFn,
+                               final Coder<AccumT> accumCoder) {
+    this.originFn = originFn;
+    this.accumCoder = accumCoder;
+  }
+
+  @Override
+  public Coder<AccumT> getAccumulatorCoder(final CoderRegistry registry, final Coder<AccumT> inputCoder)
+    throws CannotProvideCoderException {
+    return accumCoder;
+  }
+
+  @Override
+  public AccumT createAccumulator() {
+    return originFn.createAccumulator();
+  }
+
+  @Override
+  public AccumT addInput(final AccumT mutableAccumulator, final AccumT input) {
+    final AccumT result = originFn.mergeAccumulators(Arrays.asList(mutableAccumulator, input));
+    return result;
+  }
+
+  @Override
+  public AccumT mergeAccumulators(final Iterable<AccumT> accumulators) {
+    return originFn.mergeAccumulators(accumulators);
+  }
+
+  @Override
+  public AccumT extractOutput(final AccumT accumulator) {
+    return accumulator;
+  }
+}


### PR DESCRIPTION
JIRA: [NEMO-472: Fix and Implement Hierarchical Aggregation](https://issues.apache.org/jira/projects/NEMO/issues/NEMO-472)

**Major changes:**
- Implemented intermediate combine: will be used in hierarchical aggregation, which will be added soon.
* Split Beam Combine PerKey transform into 3 step (previously 2 step)
1. partial combine
2. intermediate combine (added, optional)
3. final combine
- Implemented unit tests

**Minor changes to note:**
- None

**Tests for the changes:**
- Tested on my Mac and ubuntu machine

**Other comments:**
- None