### PR TITLE
[MINOR] Fix Travis script to run with LTS node version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,7 @@ env:
   jobs:
     - GOAL="verify -B -q -ff -Dsurefire.useFile=false -Dorg.slf4j.simpleLogger.defaultLogLevel=info"
 before_install:
-  - sudo apt-get -y install gcc g++
-  - nvm install node  # for Web UI build
+  - nvm install --lts # for Web UI build
 install: true
 script:
   # the following command line builds the project, runs the tests with coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ env:
   jobs:
     - GOAL="verify -B -q -ff -Dsurefire.useFile=false -Dorg.slf4j.simpleLogger.defaultLogLevel=info"
 before_install:
+  - sudo apt-get -y install gcc g++
   - nvm install node  # for Web UI build
 install: true
 script:


### PR DESCRIPTION
**Major changes:**
- None

**Minor changes to note:**
- It adds installation of node dependencies with LTS version

**Tests for the changes:**
- Existing tests comply

**Other comments:**
- Node on versions 18 newly requires manual installation of other libraries on Ubuntu servers

Closes #331
