### PR TITLE
[WIP] [MINOR] Migrate from travis to GitHub actions

### DIFF
--- a/maven.yml
+++ b/maven.yml
@@ -1,0 +1,33 @@
+# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-maven
+
+name: Java CI with Maven
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+    name: Build on Java ${{ matrix.java_version }} and ${{ matrix.os }}
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        java_version: ['8', '11']
+        os: [ubuntu-latest, ubuntu-18.04]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        java-version: ${{ matrix.java_version }}
+        distribution: 'adopt'
+        cache: maven
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml
+
+# We need node testing too


### PR DESCRIPTION
**Major changes:**
- As Travis CI is discontinuing the free CI build for open source projects, we should migrate to Github actions, as suggested by ASF. (https://cwiki.apache.org/confluence/display/INFRA/Travis+Migrations)

**Minor changes to note:**
- None

**Tests for the changes:**
- None

**Other comments:**
- None

Closes #339

